### PR TITLE
block: fixed partial write in 8f94710

### DIFF
--- a/block.go
+++ b/block.go
@@ -235,41 +235,35 @@ func (b *block) append(args []driver.Value) error {
 				return err
 			}
 		case enum8:
-			ident, ok := args[columnNum].(string)
-			if !ok {
-				// Attempt to serialise as integer type without ident checking
-				if err := write(buffer, info, args[columnNum]); err == nil {
-					return nil
-				}
-				return fmt.Errorf("Column %s (%s): invalid ident type %T", column, b.columnTypes[columnNum], args[columnNum])
-			}
 			var (
-				enum       = enum(v)
-				value, err = enum.toValue(ident)
+				value interface{} = args[columnNum]
+				err   error
 			)
+			// If argument is string, resolve identifier to value
+			ident, ok := args[columnNum].(string)
+			if ok {
+				value, err = enum(v).toValue(ident)
+			}
 			if err != nil {
 				return fmt.Errorf("Column %s (%s): %s", column, b.columnTypes[columnNum], err.Error())
 			}
-			if err := write(buffer, v, value); err != nil {
+			if err := write(buffer, info, value); err != nil {
 				return fmt.Errorf("Column %s (%s): %s", column, b.columnTypes[columnNum], err.Error())
 			}
 		case enum16:
-			ident, ok := args[columnNum].(string)
-			if !ok {
-				// Attempt to serialise as integer type without ident checking
-				if err := write(buffer, info, args[columnNum]); err == nil {
-					return nil
-				}
-				return fmt.Errorf("Column %s (%s): invalid ident type %T", column, b.columnTypes[columnNum], args[columnNum])
-			}
 			var (
-				enum       = enum(v)
-				value, err = enum.toValue(ident)
+				value interface{} = args[columnNum]
+				err   error
 			)
+			// If argument is string, resolve identifier to value
+			ident, ok := args[columnNum].(string)
+			if ok {
+				value, err = enum(v).toValue(ident)
+			}
 			if err != nil {
 				return fmt.Errorf("Column %s (%s): %s", column, b.columnTypes[columnNum], err.Error())
 			}
-			if err := write(buffer, v, value); err != nil {
+			if err := write(buffer, info, value); err != nil {
 				return fmt.Errorf("Column %s (%s): %s", column, b.columnTypes[columnNum], err.Error())
 			}
 		default:


### PR DESCRIPTION
The loop returned nil in case of success, which terminated the write loop for all columns too early if the written enum wasn’t the last column in the set. 