### PR TITLE
columnar writer interface

### DIFF
--- a/examples/columnar.go
+++ b/examples/columnar.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"database/sql/driver"
+	"log"
+	"time"
+
+	"github.com/kshvakov/clickhouse"
+)
+
+func main() {
+	connect, err := clickhouse.Open("tcp://127.0.0.1:9000?username=&debug=true")
+	if err != nil {
+		log.Fatal(err)
+	}
+	{
+		tx, _ := connect.Begin()
+		stmt, _ := connect.Prepare(`
+			CREATE TABLE IF NOT EXISTS example (
+				os_id        UInt8,
+				action_day   Date,
+			) engine=Memory
+		`)
+
+		if _, err := stmt.Exec([]driver.Value{}); err != nil {
+			log.Fatal(err)
+		}
+		tx.Commit()
+	}
+	{
+		tx, _ := connect.Begin()
+		stmt, _ := connect.Prepare("INSERT INTO example (os_id, action_day) VALUES (?, ?)")
+		cstmt, ok := stmt.(clickhouse.ColumnarStatement)
+		if !ok {
+			log.Fatal("Column writer is not supported")
+		}
+
+		w := cstmt.ColumnWriter()
+		for i := 0; i < 100; i++ {
+			w.WriteUInt8(0, uint8(10+i))
+		}
+
+		for i := 0; i < 100; i++ {
+			w.WriteDate(1, time.Now())
+		}
+
+		if err := cstmt.ColumnWriterEnd(100); err != nil {
+			log.Fatal(err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			log.Fatal(err)
+		}
+	}
+	{
+		tx, _ := connect.Begin()
+		stmt, _ := connect.Prepare(`DROP TABLE example`)
+
+		if _, err := stmt.Exec([]driver.Value{}); err != nil {
+			log.Fatal(err)
+		}
+		tx.Commit()
+	}
+}

--- a/write_column.go
+++ b/write_column.go
@@ -1,0 +1,127 @@
+package clickhouse
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"time"
+)
+
+// Statement supporting columnar writer
+type ColumnarStatement interface {
+	ColumnWriter() ColumnWriter
+	ColumnWriterEnd(rows uint64) error
+}
+
+func (stmt *stmt) ColumnWriter() ColumnWriter {
+	stmt.ch.data.reserveColumns()
+	return stmt.ch.data
+}
+
+func (stmt *stmt) ColumnWriterEnd(rows uint64) error {
+	writtenBlocks := stmt.counter / stmt.ch.blockSize
+	stmt.counter += int(rows)
+	stmt.ch.data.numRows += rows
+
+	var err error
+	if stmt.counter/stmt.ch.blockSize > writtenBlocks {
+		err = stmt.ch.data.write(stmt.ch.serverRevision, stmt.ch.conn)
+	}
+	return err
+}
+
+// Interface for block writer allowing writes to individual columns
+type ColumnWriter interface {
+	WriteDate(c int, v time.Time) error
+	WriteDateTime(c int, v time.Time) error
+	WriteUInt8(c int, v uint8) error
+	WriteUInt16(c int, v uint16) error
+	WriteUInt32(c int, v uint32) error
+	WriteUInt64(c int, v uint64) error
+	WriteFloat32(c int, v float32) error
+	WriteFloat64(c int, v float64) error
+	WriteBytes(c int, v []byte) error
+	WriteString(c int, v string) error
+	WriteFixedString(c int, v []byte) error
+}
+
+func (b *block) WriteDate(c int, v time.Time) error {
+	binary.LittleEndian.PutUint16(b.buffers[c].alloc(2), uint16(v.Unix()/24/3600))
+	return nil
+}
+
+func (b *block) WriteDateTime(c int, v time.Time) error {
+	binary.LittleEndian.PutUint32(b.buffers[c].alloc(4), uint32(v.Unix()))
+	return nil
+}
+
+func (b *block) WriteUInt8(c int, v uint8) error {
+	buf := b.buffers[c].alloc(1)
+	buf[0] = v
+	return nil
+}
+
+func (b *block) WriteUInt16(c int, v uint16) error {
+	binary.LittleEndian.PutUint16(b.buffers[c].alloc(2), v)
+	return nil
+}
+
+func (b *block) WriteUInt32(c int, v uint32) error {
+	binary.LittleEndian.PutUint32(b.buffers[c].alloc(4), v)
+	return nil
+}
+
+func (b *block) WriteUInt64(c int, v uint64) error {
+	binary.LittleEndian.PutUint64(b.buffers[c].alloc(8), v)
+	return nil
+}
+
+func (b *block) WriteFloat32(c int, v float32) error {
+	binary.LittleEndian.PutUint32(b.buffers[c].alloc(4), math.Float32bits(v))
+	return nil
+}
+
+func (b *block) WriteFloat64(c int, v float64) error {
+	binary.LittleEndian.PutUint64(b.buffers[c].alloc(8), math.Float64bits(v))
+	return nil
+}
+
+func (b *block) WriteBytes(c int, v []byte) error {
+	scratch := make([]byte, binary.MaxVarintLen64)
+	vlen := binary.PutUvarint(scratch, uint64(len(v)))
+	if _, err := b.buffers[c].Write(scratch[:vlen]); err != nil {
+		return err
+	}
+	if _, err := b.buffers[c].Write(v); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *block) WriteString(c int, v string) error {
+	scratch := make([]byte, binary.MaxVarintLen64)
+	vlen := binary.PutUvarint(scratch, uint64(len(v)))
+	if _, err := b.buffers[c].Write(scratch[:vlen]); err != nil {
+		return err
+	}
+	if _, err := b.buffers[c].Write([]byte(v)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *block) WriteFixedString(c int, v []byte) error {
+	strlen := len(b.columnInfo[c].([]byte))
+	if len(v) > strlen {
+		return fmt.Errorf("too large value")
+	} else if len(v) == 0 {
+		// When empty, insert default value to avoid allocation
+		v = b.columnInfo[c].([]byte)
+	} else if len(v) < strlen {
+		fixedString := make([]byte, strlen)
+		copy(fixedString, v)
+		v = fixedString
+	}
+	_, err := b.buffers[c].Write(v)
+	return err
+}


### PR DESCRIPTION
Hi, this does some optimisations and implements a columnar writer interface for high throughput insertions. See the commit messages for more information, but here's the gist:

* writeBuffer growing strategy is now O(1) and uses just normal doubling of previous chunk size
* new interface for statement to support inserts directly into columns

For my bulk insertions case it's about 2x faster overall with half the memory usage and less gc pauses.