### PR TITLE
write_buffer: recycle buffer chunks, not buffers

### DIFF
--- a/block.go
+++ b/block.go
@@ -5,15 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 )
-
-// Recycle column buffers, preallocate column buffers
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		return wb(256 * 1024)
-	},
-}
 
 // data block
 type block struct {
@@ -196,8 +188,8 @@ func (b *block) reserveColumns() {
 		b.buffers = make([]*writeBuffer, columnCount)
 		b.offsetBuffers = make([]*writeBuffer, columnCount)
 		for i := 0; i < columnCount; i++ {
-			b.buffers[i] = bufferPool.Get().(*writeBuffer)
-			b.offsetBuffers[i] = bufferPool.Get().(*writeBuffer)
+			b.buffers[i] = wb(WriteBufferInitialSize)
+			b.offsetBuffers[i] = wb(WriteBufferInitialSize)
 		}
 	}
 }
@@ -311,7 +303,6 @@ func (b *block) reset() {
 	}
 	for _, b := range b.buffers {
 		b.free()
-		bufferPool.Put(b)
 	}
 	b.buffers = nil
 }

--- a/write_buffer_test.go
+++ b/write_buffer_test.go
@@ -32,7 +32,7 @@ func Test_WriteBuffer(t *testing.T) {
 				{
 					if assert.Len(t, wb.chunks, 1) {
 						if assert.Equal(t, int(0), wb.len()) {
-							assert.Equal(t, int(10), cap(wb.chunks[0]))
+							assert.Equal(t, int(64), cap(wb.chunks[0]))
 						}
 					}
 				}
@@ -52,7 +52,7 @@ func Test_WriteBuffer(t *testing.T) {
 				{
 					if assert.Len(t, wb.chunks, 1) {
 						if assert.Equal(t, int(0), wb.len()) {
-							assert.Equal(t, int(10), cap(wb.chunks[0]))
+							assert.Equal(t, int(64), cap(wb.chunks[0]))
 						}
 					}
 				}


### PR DESCRIPTION
since aae5960 only the slice holding memory
chunks was recycled, not the data backing the
buffers

this moves memory recycling to write_buffer and
recycles memory chunks backing the buffer.
to play nice with memory growing strategy,
smallest chunks are released instead of recycling,
which makes memory pool keep larger chunks when
the memory usage rises