### PR TITLE
Add support IP argument type

### DIFF
--- a/ip.go
+++ b/ip.go
@@ -1,0 +1,69 @@
+/*
+IP type supporting for clickhouse as FixedString(16)
+*/
+
+package clickhouse
+
+import (
+	"database/sql/driver"
+	"errors"
+	"net"
+)
+
+var (
+	errInvalidScanType  = errors.New("Invalid scan types")
+	errInvalidScanValue = errors.New("Invalid scan value")
+)
+
+// IP column type
+type IP net.IP
+
+// Value implements the driver.Valuer interface, json field interface
+// Alignment on the right side
+func (ip IP) Value() (driver.Value, error) {
+	if len(ip) < 16 {
+		var (
+			buff = make([]byte, 16)
+			j    = 0
+		)
+		for i := 16 - len(ip); i < 16; i++ {
+			buff[i] = ip[j]
+			j++
+		}
+		for i := 0; i < 16-len(ip); i++ {
+			buff[i] = '\x00'
+		}
+		if len(ip) == 4 {
+			buff[11] = '\xff'
+			buff[10] = '\xff'
+		}
+		return buff, nil
+	}
+	return []byte(ip), nil
+}
+
+// Scan implements the driver.Valuer interface, json field interface
+func (ip *IP) Scan(value interface{}) (err error) {
+	switch v := value.(type) {
+	case []byte:
+		if len(v) == 4 || len(v) == 16 {
+			*ip = IP(v)
+		} else {
+			err = errInvalidScanValue
+		}
+	case string:
+		if len(v) == 4 || len(v) == 16 {
+			*ip = IP([]byte(v))
+		} else {
+			err = errInvalidScanValue
+		}
+	default:
+		err = errInvalidScanType
+	}
+	return
+}
+
+// String implements the fmt.Stringer interface
+func (ip IP) String() string {
+	return net.IP(ip).String()
+}

--- a/ip_test.go
+++ b/ip_test.go
@@ -1,0 +1,44 @@
+package clickhouse
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+var ipAddresses = []string{
+	"127.0.0.1",
+	"99.67.1.100",
+	"::1",
+	"2001:0db8:0a0b:12f0:0000:0000:0000:0001",
+	"2001:0db8::0001",
+	"3731:54:65fe:2::a7",
+}
+
+func Test_IPConverter(t *testing.T) {
+	for _, ips := range ipAddresses {
+		var (
+			ip2        IP
+			ip         = net.ParseIP(ips)
+			value, err = IP(ip).Value()
+		)
+
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if err == nil {
+			if !strings.Contains(ips, ":") {
+				vl := value.([]byte)
+				err = ip2.Scan(vl[len(vl)-4:])
+			} else {
+				err = ip2.Scan(value)
+			}
+		}
+
+		if !ip.Equal(net.IP(ip2)) {
+			t.Errorf("Invalid ip restore: %s != %s", ip, ip2)
+		}
+	}
+}

--- a/value_converter.go
+++ b/value_converter.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"reflect"
 )
 
@@ -57,6 +58,8 @@ func (c *converter) ConvertValue(v interface{}) (driver.Value, error) {
 		[]uint, []uint8, []uint16, []uint32, []uint64,
 		[]string:
 		return (&array{values: v}).Value()
+	case net.IP:
+		return IP(value).Value()
 	}
 
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr {


### PR DESCRIPTION
Implemented native support of type net.IP into the driver.
IP type should be always FixedString(16).