### PR TITLE
Fix race issue

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -23,7 +23,7 @@ func dial(network string, hosts []string, noDelay bool, r, w time.Duration, logf
 	)
 	for i := 0; i <= len(hosts); i++ {
 		if conn, err = net.DialTimeout(network, hosts[(index+1)%len(hosts)], 2*time.Second); err == nil {
-			logf("[connect] num=%d -> %s", tick, conn.RemoteAddr())
+			logf("[connect] num=%d -> %s", atomic.LoadInt32(&tick), conn.RemoteAddr())
 			if tcp, ok := conn.(*net.TCPConn); ok {
 				tcp.SetNoDelay(noDelay) // Disable or enable the Nagle Algorithm for this tcp socket
 			}


### PR DESCRIPTION
There is a race bug, when a lot of opened connections in multiple goroutines tries to read `tick` address

```
==================
WARNING: DATA RACE
Read at 0x000001463c94 by goroutine 12:
  runtime.convT2E()
      /usr/local/go/src/runtime/iface.go:191 +0x0
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:26 +0x1da
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Previous write at 0x000001463c94 by goroutine 23:
  sync/atomic.AddInt32()
      /usr/local/go/src/runtime/race_amd64.s:269 +0xb
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:22 +0x57
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Goroutine 12 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d

Goroutine 23 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d
==================
==================
WARNING: DATA RACE
Read at 0x000001463c94 by goroutine 62:
  runtime.convT2E()
      /usr/local/go/src/runtime/iface.go:191 +0x0
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:26 +0x1da
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Previous write at 0x000001463c94 by goroutine 23:
  sync/atomic.AddInt32()
      /usr/local/go/src/runtime/race_amd64.s:269 +0xb
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:22 +0x57
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Goroutine 62 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d

Goroutine 23 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d
==================
==================
WARNING: DATA RACE
Read at 0x000001463c94 by goroutine 10:
  runtime.convT2E()
      /usr/local/go/src/runtime/iface.go:191 +0x0
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:26 +0x1da
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Previous write at 0x000001463c94 by goroutine 23:
  sync/atomic.AddInt32()
      /usr/local/go/src/runtime/race_amd64.s:269 +0xb
  backend/vendor/github.com/kshvakov/clickhouse.dial()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/connect.go:22 +0x57
  backend/vendor/github.com/kshvakov/clickhouse.Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:103 +0xa5a
  backend/vendor/github.com/kshvakov/clickhouse.(*bootstrap).Open()
      /test/src/backend/vendor/github.com/kshvakov/clickhouse/bootstrap.go:47 +0x46
  database/sql.(*DB).conn()
      /usr/local/go/src/database/sql/sql.go:965 +0x228
  database/sql.(*Stmt).connStmt()
      /usr/local/go/src/database/sql/sql.go:1903 +0x360
  database/sql.(*Stmt).QueryContext()
      /usr/local/go/src/database/sql/sql.go:1941 +0xf5
  database/sql.(*Stmt).Query()
      /usr/local/go/src/database/sql/sql.go:1978 +0x88
  backend/shared/cache/assets.GetMissedFrame()
      /test/src/backend/shared/cache/assets/utils.go:23 +0x276
  main.main.func1()
      /test/src/backend/test.go:30 +0x10e

Goroutine 10 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d

Goroutine 23 (running) created at:
  main.main()
      /test/src/backend/test.go:31 +0x20d
```

