### PR TITLE
use Valuer interface when write custom types into ClickHouse

### DIFF
--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -123,7 +123,15 @@ func (block *Block) AppendRow(args []driver.Value) error {
 				return err
 			}
 		default:
-			if err := column.Write(block.Buffers[num].Column, args[num]); err != nil {
+			var val interface{} = args[num]
+			var err error
+			if v, ok := val.(driver.Valuer); ok {
+				val, err = v.Value()
+				if err != nil {
+					return err
+				}
+			}
+			if err := column.Write(block.Buffers[num].Column, val); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Hi!
I try use custom data type CustomType and write it into ClickHouse table in UInt32 column. My code looks like this:
```
package main

import (
    "log"
    "github.com/kshvakov/clickhouse"
    "database/sql"
    "database/sql/driver"
    "fmt"
)

type CustomType uint32

func (v CustomType) Value() (driver.Value, error) {
	return uint32(v), nil
}

func main() {
    connect, err := sql.Open("clickhouse", "tcp://ch.host:9000?database=db&debug=true")
    if err != nil {
        log.Fatal(err)
    }
    if err := connect.Ping(); err != nil {
        if exception, ok := err.(*clickhouse.Exception); ok {
            fmt.Printf("[%d] %s \n%s\n", exception.Code, exception.Message, exception.StackTrace)
        } else {
            fmt.Println(err)
        }
        return
    }

    _, err = connect.Exec(`
        CREATE TABLE IF NOT EXISTS example (
            clm        UInt32,
        ) engine=Memory
    `)
    if err != nil {
        log.Fatal(err)
    }
    var (
        tx, _   = connect.Begin()
        stmt, _ = tx.Prepare("INSERT INTO example (clm) VALUES (?)")
    )

    v := CustomType(123)
    if _, err := stmt.Exec(v); err != nil {
        log.Fatal(err)
    }

    if err := tx.Commit(); err != nil {
        log.Fatal(err)
    }
}
```

But I get error like:

>  clm (UInt32): unexpected type CustomType

I investigate lib and find that [Valuer interface](https://golang.org/pkg/database/sql/driver/#Valuer) nowhere use. I slightly hack lib and now it work. But I don't know if it good place for this check or maybe write it's code in another place.

I think scanner interface not used too, I think it will be second pull request :)