### PR TITLE
Support for passing limit number as bind parameter

### DIFF
--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -344,6 +344,42 @@ func Test_Select(t *testing.T) {
 									assert.Equal(t, int(3), count)
 								}
 							}
+							if rows, err := connect.Query("SELECT id FROM clickhouse_test_select ORDER BY id LIMIT ?", 1); assert.NoError(t, err) {
+								i := 0
+								for rows.Next() {
+									var (
+										id int32
+									)
+									if err := rows.Scan(&id); assert.NoError(t, err) {
+										if i == 0 {
+											assert.Equal(t, id, int32(1))
+										} else {
+											t.Error("Should return exactly one record")
+										}
+									}
+									i++
+								}
+								rows.Close()
+							}
+							if rows, err := connect.Query("SELECT id FROM clickhouse_test_select ORDER BY id LIMIT ?,?", 1, 2); assert.NoError(t, err) {
+								i := 0
+								for rows.Next() {
+									var (
+										id int32
+									)
+									if err := rows.Scan(&id); assert.NoError(t, err) {
+										if i == 0 {
+											assert.Equal(t, id, int32(2))
+										} else if i == 1 {
+											assert.Equal(t, id, int32(3))
+										} else {
+											t.Error("Should return exactly two records")
+										}
+									}
+									i++
+								}
+								rows.Close()
+							}
 						}
 
 						{

--- a/helpers.go
+++ b/helpers.go
@@ -46,11 +46,13 @@ func (datetime DateTime) convert() time.Time {
 }
 
 func numInput(query string) int {
+
 	var (
 		count          int
 		args           = make(map[string]struct{})
 		reader         = bytes.NewReader([]byte(query))
 		quote, keyword bool
+		limit          = newMatcher("limit")
 	)
 	for {
 		if char, _, err := reader.ReadRune(); err == nil {
@@ -81,7 +83,11 @@ func numInput(query string) int {
 				char == '[':
 				keyword = true
 			default:
-				keyword = keyword && (char == ' ' || char == '\t' || char == '\n')
+				if limit.matchRune(char) {
+					keyword = true
+				} else {
+					keyword = keyword && (char == ' ' || char == '\t' || char == '\n')
+				}
 			}
 		} else {
 			break

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -27,8 +27,8 @@ func Test_NumInput(t *testing.T) {
 			?
 		)
 		`: 3,
-		"SELECT * from EXAMPLE LIMIT ?":          1,
-		"SELECT * from EXAMPLE LIMIT ? OFFSET ?": 2,
+		"SELECT * from EXAMPLE LIMIT ?":    1,
+		"SELECT * from EXAMPLE LIMIT ?, ?": 2,
 	} {
 		assert.Equal(t, num, numInput(query), query)
 	}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -27,6 +27,8 @@ func Test_NumInput(t *testing.T) {
 			?
 		)
 		`: 3,
+		"SELECT * from EXAMPLE LIMIT ?":          1,
+		"SELECT * from EXAMPLE LIMIT ? OFFSET ?": 2,
 	} {
 		assert.Equal(t, num, numInput(query), query)
 	}

--- a/stmt.go
+++ b/stmt.go
@@ -106,6 +106,7 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 		buf     bytes.Buffer
 		index   int
 		keyword bool
+		limit   = newMatcher("limit")
 	)
 	switch {
 	case stmt.NumInput() != 0:
@@ -140,7 +141,11 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 						char == '[':
 						keyword = true
 					default:
-						keyword = keyword && (char == ' ' || char == '\t' || char == '\n')
+						if limit.matchRune(char) {
+							keyword = true
+						} else {
+							keyword = keyword && (char == ' ' || char == '\t' || char == '\n')
+						}
 					}
 					buf.WriteRune(char)
 				}

--- a/word_matcher.go
+++ b/word_matcher.go
@@ -1,0 +1,31 @@
+package clickhouse
+
+import (
+	"strings"
+	"unicode"
+)
+
+// wordMatcher is a simple automata to match a single word (case insensitive)
+type wordMatcher struct {
+	word     []rune
+	position uint8
+}
+
+// newMatcher returns matcher for word needle
+func newMatcher(needle string) *wordMatcher {
+	return &wordMatcher{word: []rune(strings.ToUpper(needle)),
+		position: 0}
+}
+
+func (m *wordMatcher) matchRune(r rune) bool {
+	if m.word[m.position] == unicode.ToUpper(r) {
+		if m.position == uint8(len(m.word)-1) {
+			m.position = 0
+			return true
+		}
+		m.position++
+	} else {
+		m.position = 0
+	}
+	return false
+}

--- a/word_matcher_test.go
+++ b/word_matcher_test.go
@@ -1,0 +1,39 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type wmTest struct {
+	haystack string
+	needle   string
+	expect   bool
+}
+
+func checkMatch(haystack, needle string) bool {
+	m := newMatcher(needle)
+	for _, r := range []rune(haystack) {
+		if m.matchRune(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWordMatcher(t *testing.T) {
+
+	table := []wmTest{
+		wmTest{"select * from test", "select", true},
+		wmTest{"select * from test", "*", true},
+		wmTest{"select * from test", "elect", true},
+		wmTest{"select * from test", "zelect", false},
+		wmTest{"select * from test", "sElEct", true},
+	}
+
+	for _, test := range table {
+		assert.Equal(t, checkMatch(test.haystack, test.needle), test.expect, test.haystack)
+	}
+
+}


### PR DESCRIPTION
In current master this would not work:
`select * from table limit ?`
It just does not see `?` placeholder after `limit` and therefore does not substitute.
I have added support for this and corresponding tests.
