### PR TITLE
Fixing the problem with panic "sql: Register called twice for driver"

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/demdxx/clickhouse/lib/column"
 	"github.com/kshvakov/clickhouse/lib/binary"
+	"github.com/kshvakov/clickhouse/lib/column"
 	"github.com/kshvakov/clickhouse/lib/data"
 	"github.com/kshvakov/clickhouse/lib/protocol"
 	"github.com/kshvakov/clickhouse/lib/types"

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/demdxx/clickhouse/lib/column"
 	"github.com/kshvakov/clickhouse/lib/binary"
 	"github.com/kshvakov/clickhouse/lib/data"
 	"github.com/kshvakov/clickhouse/lib/protocol"
@@ -165,7 +166,7 @@ func (ch *clickhouse) Rollback() error {
 
 func (ch *clickhouse) CheckNamedValue(nv *driver.NamedValue) error {
 	switch nv.Value.(type) {
-	case IP, *types.Array, UUID:
+	case column.IP, *types.Array, column.UUID:
 		return nil
 	case nil, []byte, int8, int16, int32, int64, uint8, uint16, uint32, uint64, float32, float64, string, time.Time:
 		return nil
@@ -179,7 +180,7 @@ func (ch *clickhouse) CheckNamedValue(nv *driver.NamedValue) error {
 		[]string:
 		nv.Value = types.NewArray(v)
 	case net.IP:
-		nv.Value = IP(v)
+		nv.Value = column.IP(v)
 	case driver.Valuer:
 		value, err := v.Value()
 		if err != nil {

--- a/clickhouse_direct_test.go
+++ b/clickhouse_direct_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/demdxx/clickhouse/lib/column"
-	"github.com/demdxx/clickhouse/lib/types"
 	"github.com/kshvakov/clickhouse"
+	"github.com/kshvakov/clickhouse/lib/column"
+	"github.com/kshvakov/clickhouse/lib/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/clickhouse_direct_test.go
+++ b/clickhouse_direct_test.go
@@ -3,11 +3,14 @@ package clickhouse_test
 import (
 	"database/sql/driver"
 	"fmt"
+
 	//	"fmt"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/demdxx/clickhouse/lib/column"
+	"github.com/demdxx/clickhouse/lib/types"
 	"github.com/kshvakov/clickhouse"
 	"github.com/stretchr/testify/assert"
 )
@@ -122,8 +125,8 @@ func Test_DirectInsert(t *testing.T) {
 							"a",
 							"d",
 
-							clickhouse.UUID("123e4567-e89b-12d3-a456-426655440000"),
-							clickhouse.IP(net.ParseIP("127.0.0.1")),
+							types.UUID("123e4567-e89b-12d3-a456-426655440000"),
+							column.IP(net.ParseIP("127.0.0.1")),
 						})
 						if !assert.NoError(t, err) {
 							return

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/demdxx/clickhouse/lib/column"
-	"github.com/demdxx/clickhouse/lib/types"
 	"github.com/kshvakov/clickhouse"
+	"github.com/kshvakov/clickhouse/lib/column"
+	"github.com/kshvakov/clickhouse/lib/types"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/demdxx/clickhouse/lib/column"
+	"github.com/demdxx/clickhouse/lib/types"
 	"github.com/kshvakov/clickhouse"
 	"github.com/stretchr/testify/assert"
 )
@@ -301,7 +303,7 @@ func Test_Select(t *testing.T) {
 			if _, err := connect.Exec(ddl); assert.NoError(t, err) {
 				if tx, err := connect.Begin(); assert.NoError(t, err) {
 					if stmt, err := tx.Prepare(dml); assert.NoError(t, err) {
-						if _, err := stmt.Exec(1, "RU", clickhouse.Date(time.Date(2017, 1, 20, 0, 0, 0, 0, time.Local)), time.Date(2017, 1, 20, 13, 0, 0, 0, time.Local)); !assert.NoError(t, err) {
+						if _, err := stmt.Exec(1, "RU", types.Date(time.Date(2017, 1, 20, 0, 0, 0, 0, time.Local)), time.Date(2017, 1, 20, 13, 0, 0, 0, time.Local)); !assert.NoError(t, err) {
 							return
 						}
 						if _, err := stmt.Exec(2, "UA", time.Date(2017, 1, 20, 0, 0, 0, 0, time.UTC), time.Date(2017, 1, 20, 14, 0, 0, 0, time.Local)); !assert.NoError(t, err) {
@@ -960,7 +962,7 @@ func Test_UUID(t *testing.T) {
 				if _, err := tx.Exec(ddl); assert.NoError(t, err) {
 					if tx, err := connect.Begin(); assert.NoError(t, err) {
 						if stmt, err := tx.Prepare("INSERT INTO clickhouse_test_uuid VALUES(?)"); assert.NoError(t, err) {
-							if _, err := stmt.Exec(clickhouse.UUID("123e4567-e89b-12d3-a456-426655440000"), "123e4567-e89b-12d3-a456-426655440000"); !assert.NoError(t, err) {
+							if _, err := stmt.Exec(types.UUID("123e4567-e89b-12d3-a456-426655440000"), "123e4567-e89b-12d3-a456-426655440000"); !assert.NoError(t, err) {
 								t.Fatal(err)
 							}
 						}
@@ -972,13 +974,13 @@ func Test_UUID(t *testing.T) {
 					if rows, err := connect.Query("SELECT UUID, UUIDNumToString(UUID), Builtin FROM clickhouse_test_uuid"); assert.NoError(t, err) {
 						if assert.True(t, rows.Next()) {
 							var (
-								uuid        clickhouse.UUID
+								uuid        types.UUID
 								uuidStr     string
 								builtinUUID string
 							)
 							if err := rows.Scan(&uuid, &uuidStr, &builtinUUID); assert.NoError(t, err) {
 								if assert.Equal(t, "123e4567-e89b-12d3-a456-426655440000", uuidStr) {
-									assert.Equal(t, clickhouse.UUID("123e4567-e89b-12d3-a456-426655440000"), uuid)
+									assert.Equal(t, types.UUID("123e4567-e89b-12d3-a456-426655440000"), uuid)
 									assert.Equal(t, "123e4567-e89b-12d3-a456-426655440000", builtinUUID)
 								}
 							}
@@ -1009,7 +1011,7 @@ func Test_IP(t *testing.T) {
 				if _, err := tx.Exec(ddl); assert.NoError(t, err) {
 					if tx, err := connect.Begin(); assert.NoError(t, err) {
 						if stmt, err := tx.Prepare("INSERT INTO clickhouse_test_ip VALUES(?, ?)"); assert.NoError(t, err) {
-							if _, err := stmt.Exec(clickhouse.IP(ipv4), clickhouse.IP(ipv6)); !assert.NoError(t, err) {
+							if _, err := stmt.Exec(column.IP(ipv4), column.IP(ipv6)); !assert.NoError(t, err) {
 								t.Fatal(err)
 							}
 						}
@@ -1019,7 +1021,7 @@ func Test_IP(t *testing.T) {
 					}
 					if rows, err := connect.Query("SELECT IPv4, IPv6 FROM clickhouse_test_ip"); assert.NoError(t, err) {
 						if assert.True(t, rows.Next()) {
-							var v4, v6 clickhouse.IP
+							var v4, v6 column.IP
 							if err := rows.Scan(&v4, &v6); assert.NoError(t, err) {
 								if assert.Equal(t, ipv4, net.IP(v4)) {
 									assert.Equal(t, ipv6, net.IP(v6))

--- a/helpers.go
+++ b/helpers.go
@@ -10,41 +10,6 @@ import (
 	"time"
 )
 
-// Truncate timezone
-//
-//   clickhouse.Date(time.Date(2017, 1, 1, 0, 0, 0, 0, time.Local)) -> time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
-type Date time.Time
-
-func (date Date) Value() (driver.Value, error) {
-	return date.convert(), nil
-}
-
-func (date Date) convert() time.Time {
-	return time.Date(time.Time(date).Year(), time.Time(date).Month(), time.Time(date).Day(), 0, 0, 0, 0, time.UTC)
-}
-
-// Truncate timezone
-//
-//   clickhouse.DateTime(time.Date(2017, 1, 1, 0, 0, 0, 0, time.Local)) -> time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
-type DateTime time.Time
-
-func (datetime DateTime) Value() (driver.Value, error) {
-	return datetime.convert(), nil
-}
-
-func (datetime DateTime) convert() time.Time {
-	return time.Date(
-		time.Time(datetime).Year(),
-		time.Time(datetime).Month(),
-		time.Time(datetime).Day(),
-		time.Time(datetime).Hour(),
-		time.Time(datetime).Minute(),
-		time.Time(datetime).Second(),
-		0,
-		time.UTC,
-	)
-}
-
 func numInput(query string) int {
 
 	var (

--- a/lib/column/ip.go
+++ b/lib/column/ip.go
@@ -2,7 +2,7 @@
 IP type supporting for clickhouse as FixedString(16)
 */
 
-package clickhouse
+package column
 
 import (
 	"database/sql/driver"

--- a/lib/column/ip_test.go
+++ b/lib/column/ip_test.go
@@ -1,4 +1,4 @@
-package clickhouse
+package column
 
 import (
 	"fmt"

--- a/lib/column/uuid_test.go
+++ b/lib/column/uuid_test.go
@@ -1,4 +1,4 @@
-package clickhouse
+package column
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/lib/types/date.go
+++ b/lib/types/date.go
@@ -1,0 +1,48 @@
+// Timezoneless date/datetime types
+
+package types
+
+import (
+	"database/sql/driver"
+	"time"
+)
+
+// Truncate timezone
+//
+//   clickhouse.Date(time.Date(2017, 1, 1, 0, 0, 0, 0, time.Local)) -> time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
+type Date time.Time
+
+func (date Date) Value() (driver.Value, error) {
+	return date.convert(), nil
+}
+
+func (date Date) convert() time.Time {
+	return time.Date(time.Time(date).Year(), time.Time(date).Month(), time.Time(date).Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// Truncate timezone
+//
+//   clickhouse.DateTime(time.Date(2017, 1, 1, 0, 0, 0, 0, time.Local)) -> time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
+type DateTime time.Time
+
+func (datetime DateTime) Value() (driver.Value, error) {
+	return datetime.convert(), nil
+}
+
+func (datetime DateTime) convert() time.Time {
+	return time.Date(
+		time.Time(datetime).Year(),
+		time.Time(datetime).Month(),
+		time.Time(datetime).Day(),
+		time.Time(datetime).Hour(),
+		time.Time(datetime).Minute(),
+		time.Time(datetime).Second(),
+		0,
+		time.UTC,
+	)
+}
+
+var (
+	_ driver.Valuer = Date{}
+	_ driver.Valuer = DateTime{}
+)

--- a/lib/types/uuid.go
+++ b/lib/types/uuid.go
@@ -1,4 +1,4 @@
-package clickhouse
+package types
 
 import (
 	"database/sql/driver"
@@ -95,3 +95,5 @@ func xtob(x1, x2 byte) (byte, bool) {
 	b2 := xvalues[x2]
 	return (b1 << 4) | b2, b1 != 255 && b2 != 255
 }
+
+var _ driver.Valuer = UUID("")

--- a/lib/types/uuid_test.go
+++ b/lib/types/uuid_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"encoding/hex"
+	"testing"
+)
+
+func Test_UUID2Bytes(t *testing.T) {
+	bytes2uuid := func(src []byte) string {
+		var uuid [36]byte
+		hex.Encode(uuid[:], src[:4])
+		uuid[8] = '-'
+		hex.Encode(uuid[9:13], src[4:6])
+		uuid[13] = '-'
+		hex.Encode(uuid[14:18], src[6:8])
+		uuid[18] = '-'
+		hex.Encode(uuid[19:23], src[8:10])
+		uuid[23] = '-'
+		hex.Encode(uuid[24:], src[10:])
+		return string(uuid[:])
+	}
+	origin := "00000000-0000-0000-0000-000000000000"
+	if uuid, err := uuid2bytes(origin); assert.NoError(t, err) {
+		assert.Equal(t, origin, bytes2uuid(uuid))
+	}
+}
+
+func Benchmark_UUID2Bytes(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := uuid2bytes("00000000-0000-0000-0000-000000000000"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/value_converter.go
+++ b/value_converter.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"reflect"
 
-	"github.com/demdxx/clickhouse/lib/column"
+	"github.com/kshvakov/clickhouse/lib/column"
 	"github.com/kshvakov/clickhouse/lib/types"
 )
 

--- a/value_converter.go
+++ b/value_converter.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"reflect"
 
+	"github.com/demdxx/clickhouse/lib/column"
 	"github.com/kshvakov/clickhouse/lib/types"
 )
 
@@ -62,32 +63,25 @@ func (c *converter) ConvertValue(v interface{}) (driver.Value, error) {
 		[]string:
 		return (types.NewArray(v)).Value()
 	case net.IP:
-		return IP(value).Value()
+		return column.IP(value).Value()
 	case driver.Valuer:
 		return value.Value()
 	}
 
-	switch v := v.(type) {
-	case Date:
-		return v.convert(), nil
-	case DateTime:
-		return v.convert(), nil
-	default:
-		switch value := reflect.ValueOf(v); value.Kind() {
-		case reflect.Bool:
-			if value.Bool() {
-				return int64(1), nil
-			}
-			return int64(0), nil
-		case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			return value.Int(), nil
-		case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			return int64(value.Uint()), nil
-		case reflect.Float32, reflect.Float64:
-			return value.Float(), nil
-		case reflect.String:
-			return value.String(), nil
+	switch value := reflect.ValueOf(v); value.Kind() {
+	case reflect.Bool:
+		if value.Bool() {
+			return int64(1), nil
 		}
+		return int64(0), nil
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return value.Int(), nil
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(value.Uint()), nil
+	case reflect.Float32, reflect.Float64:
+		return value.Float(), nil
+	case reflect.String:
+		return value.String(), nil
 	}
 
 	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr {


### PR DESCRIPTION
It happens when you need to use some types from "clickhouse" package from other package.
So the reorganization will help to use types UUID and IP from root directory.
UUID was transferred to "lib/types" and IP to "lib/column"