### PR TITLE
Fixing the problem with alter table query execution

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -184,6 +184,9 @@ func (ch *clickhouse) hello(database, username, password string) error {
 			if err := ch.ServerInfo.Read(ch.decoder); err != nil {
 				return err
 			}
+		case protocol.ServerEndOfStream:
+			ch.logf("[bootstrap] <- end of stream")
+			return nil
 		default:
 			ch.conn.Close()
 			return fmt.Errorf("[hello] unexpected packet [%d] from server", packet)

--- a/clickhouse_read_meta.go
+++ b/clickhouse_read_meta.go
@@ -40,6 +40,10 @@ func (ch *clickhouse) readMeta() (*data.Block, error) {
 			}
 			ch.logf("[read meta] <- data: packet=%d, columns=%d, rows=%d", packet, block.NumColumns, block.NumRows)
 			return block, nil
+		case protocol.ServerEndOfStream:
+			_, err := ch.readBlock()
+			ch.logf("[process] <- end of stream")
+			return nil, err
 		default:
 			ch.conn.Close()
 			return nil, fmt.Errorf("[read meta] unexpected packet [%d] from server", packet)


### PR DESCRIPTION
While trying to remove old partitions at clickhouse with alter table, current version gives _"unexpected packet [5] from server"_ error and crashes. With this version, problem is solved.