### PR TITLE
Adding a column handler for AggregatedFunction

### DIFF
--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -129,6 +129,8 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 	}
 
 	switch {
+	case strings.HasPrefix(chType, "AggregateFunction"):
+		return parseAggregateFunction(name, chType, timezone)
 	case strings.HasPrefix(chType, "Array"):
 		return parseArray(name, chType, timezone)
 	case strings.HasPrefix(chType, "Nullable"):

--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/kshvakov/clickhouse/lib/binary"
-	columns "github.com/kshvakov/clickhouse/lib/column"
+	columns "github.com/joemadeus/clickhouse/lib/column"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -459,6 +459,14 @@ func Test_Column_UUID(t *testing.T) {
 		}
 		if err := column.Write(encoder, "invalid-uuid"); assert.Error(t, err) {
 			assert.Equal(t, columns.ErrInvalidUUIDFormat, err)
+		}
+	}
+}
+
+func Test_Column_AggregateFunction(t *testing.T) {
+	if column, err := columns.Factory("aggfunc_col", "AggregateFunction(max, UInt64)", time.Local); assert.NoError(t, err) {
+		if assert.Equal(t, "aggfunc_col", column.Name()) && assert.Equal(t, "AggregateFunction(max, UInt64)", column.CHType()) {
+			assert.Equal(t, reflect.Uint64, column.ScanType().Kind())
 		}
 	}
 }

--- a/lib/column/function.go
+++ b/lib/column/function.go
@@ -1,0 +1,43 @@
+package column
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/kshvakov/clickhouse/lib/binary"
+)
+
+type AggregateFunction struct {
+	base
+	function string
+}
+
+func (array *AggregateFunction) Read(decoder *binary.Decoder) (interface{}, error) {
+	return nil, fmt.Errorf("aggregate functions cannot be directly read")
+}
+
+func (array *AggregateFunction) Write(encoder *binary.Encoder, v interface{}) error {
+	return fmt.Errorf("aggregate functions cannot be directly written")
+}
+
+func parseAggregateFunction(name, chType string, timezone *time.Location) (*AggregateFunction, error) {
+	parensContents := strings.Split(chType[18:len(chType)-1], ",")
+	if len(parensContents) != 2 {
+		return nil, fmt.Errorf("AggregateFunction: %v", "not enough arguments")
+	}
+
+	column, err := Factory(name, strings.TrimSpace(parensContents[1]), timezone)
+	if err != nil {
+		return nil, fmt.Errorf("AggregateFunction: %v", err)
+	}
+
+	return &AggregateFunction{
+		base: base{
+			name:    name,
+			chType:  chType,
+			valueOf: reflect.ValueOf(column.ScanType()),
+		},
+	}, nil
+}

--- a/lib/column/function.go
+++ b/lib/column/function.go
@@ -12,6 +12,7 @@ import (
 type AggregateFunction struct {
 	base
 	function string
+	column Column
 }
 
 func (array *AggregateFunction) Read(decoder *binary.Decoder) (interface{}, error) {
@@ -33,11 +34,28 @@ func parseAggregateFunction(name, chType string, timezone *time.Location) (*Aggr
 		return nil, fmt.Errorf("AggregateFunction: %v", err)
 	}
 
+	var scanTypes = map[reflect.Kind]reflect.Value{
+		reflect.Int8:     reflect.ValueOf(int8(0)),
+		reflect.Int16:    reflect.ValueOf(int16(0)),
+		reflect.Int32:    reflect.ValueOf(int32(0)),
+		reflect.Int64:    reflect.ValueOf(int64(0)),
+		reflect.Uint8:    reflect.ValueOf(uint8(0)),
+		reflect.Uint16:   reflect.ValueOf(uint16(0)),
+		reflect.Uint32:   reflect.ValueOf(uint32(0)),
+		reflect.Uint64:   reflect.ValueOf(uint64(0)),
+		reflect.Float32:  reflect.ValueOf(float32(0)),
+		reflect.Float64:  reflect.ValueOf(float64(0)),
+		reflect.String:   reflect.ValueOf(string("")),
+		// not sure what to do about time.Time
+	}
+
 	return &AggregateFunction{
 		base: base{
 			name:    name,
 			chType:  chType,
-			valueOf: reflect.ValueOf(column.ScanType()),
+			valueOf: scanTypes[column.ScanType().Kind()],
 		},
+		function: strings.TrimSpace(parensContents[0]),
+		column: column,
 	}, nil
 }


### PR DESCRIPTION
Note that this is based on the v1.3.4 tag, since I'm unable to get `master` to compile or run tests. Happy to move it over to `master` if that needs be.

* Added an `AggregateFunction` type (implements `Column`) to a new file, `function.go` in the `lib/column` dir. This adds support for `AggregateFunction` columns in CH, holding the name of the aggregation function in a field named `function` and the type of its rvalue in `base.valueOf`.
* Added a `case` clause to the `Factory` func that resolves `chTypes` to `column` types.
* Added a (very) basic unit test.
