### PR TITLE
Support arithmetic operators before ? placeholders

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql/driver"
+	"unicode"
 
 	"github.com/kshvakov/clickhouse/lib/data"
 )
@@ -138,13 +139,17 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 						char == '(',
 						char == ',',
 						char == '%',
+						char == '+',
+						char == '-',
+						char == '*',
+						char == '/',
 						char == '[':
 						keyword = true
 					default:
 						if limit.matchRune(char) {
 							keyword = true
 						} else {
-							keyword = keyword && (char == ' ' || char == '\t' || char == '\n')
+							keyword = keyword && unicode.IsSpace(char)
 						}
 					}
 					buf.WriteRune(char)


### PR DESCRIPTION
Support arithmetic operators before ? placeholders by adding extra operators when looking for keywords in `stmt.bind()`