### PR TITLE
Fix random connection opening strategy

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -44,7 +44,7 @@ func dial(secure, skipVerify bool, hosts []string, readTimeout, writeTimeout tim
 		case connOpenInOrder:
 			num = i
 		case connOpenRandom:
-			num = (ident + 1) % len(hosts)
+			num = (ident + i) % len(hosts)
 		}
 		switch {
 		case secure:


### PR DESCRIPTION
Hello! It looks like random connection opening strategy was wrong: if generated index hit bad host it did not try to open other hosts. It was trying to open connection with the same bad host and then failed.