### PR TITLE
Date column reading and writing with zone offset fixed

### DIFF
--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -116,14 +116,24 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 				valueOf: baseTypes[string("")],
 			},
 		}, nil
-	case "Date", "DateTime":
+	case "Date":
+		_, offset := time.Unix(0, 0).In(timezone).Zone()
+		return &Date{
+			base: base{
+				name:    name,
+				chType:  chType,
+				valueOf: baseTypes[time.Time{}],
+			},
+			Timezone: timezone,
+			offset:   int64(offset),
+		}, nil
+	case "DateTime":
 		return &DateTime{
 			base: base{
 				name:    name,
 				chType:  chType,
 				valueOf: baseTypes[time.Time{}],
 			},
-			IsFull:   chType == "DateTime",
 			Timezone: timezone,
 		}, nil
 	}

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -17,7 +17,7 @@ func (dt *Date) Read(decoder *binary.Decoder) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return time.Unix(int64(sec)*24*3600, 0).In(dt.Timezone), nil
+	return time.Unix(int64(sec)*24*3600-dt.offset, 0).In(dt.Timezone), nil
 }
 
 func (dt *Date) Write(encoder *binary.Encoder, v interface{}) error {

--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -6,30 +6,32 @@ import (
 	"github.com/kshvakov/clickhouse/lib/binary"
 )
 
-type DateTime struct {
+type Date struct {
 	base
 	Timezone *time.Location
+	offset   int64
 }
 
-func (dt *DateTime) Read(decoder *binary.Decoder) (interface{}, error) {
-	sec, err := decoder.Int32()
+func (dt *Date) Read(decoder *binary.Decoder) (interface{}, error) {
+	sec, err := decoder.Int16()
 	if err != nil {
 		return nil, err
 	}
-	return time.Unix(int64(sec), 0).In(dt.Timezone), nil
+	return time.Unix(int64(sec)*24*3600, 0).In(dt.Timezone), nil
 }
 
-func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
+func (dt *Date) Write(encoder *binary.Encoder, v interface{}) error {
 	var timestamp int64
 	switch value := v.(type) {
 	case time.Time:
-		timestamp = value.Unix()
+		_, offset := value.Zone()
+		timestamp = value.Unix() + int64(offset)
 	case int16:
-		timestamp = int64(value)
+		timestamp = int64(value) + dt.offset
 	case int32:
-		timestamp = int64(value)
+		timestamp = int64(value) + dt.offset
 	case int64:
-		timestamp = value
+		timestamp = value + dt.offset
 	case string:
 		var err error
 		timestamp, err = dt.parse(value)
@@ -39,13 +41,14 @@ func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
 
 	// this relies on Nullable never sending nil values through
 	case *time.Time:
-		timestamp = (*value).Unix()
+		_, offset := value.Zone()
+		timestamp = (*value).Unix() + int64(offset)
 	case *int16:
-		timestamp = int64(*value)
+		timestamp = int64(*value) + dt.offset
 	case *int32:
-		timestamp = int64(*value)
+		timestamp = int64(*value) + dt.offset
 	case *int64:
-		timestamp = *value
+		timestamp = *value + dt.offset
 	case *string:
 		var err error
 		timestamp, err = dt.parse(*value)
@@ -60,11 +63,11 @@ func (dt *DateTime) Write(encoder *binary.Encoder, v interface{}) error {
 		}
 	}
 
-	return encoder.Int32(int32(timestamp))
+	return encoder.Int16(int16(timestamp / 24 / 3600))
 }
 
-func (dt *DateTime) parse(value string) (int64, error) {
-	tv, err := time.Parse("2006-01-02 15:04:05", value)
+func (dt *Date) parse(value string) (int64, error) {
+	tv, err := time.Parse("2006-01-02", value)
 	if err != nil {
 		return 0, err
 	}
@@ -72,9 +75,6 @@ func (dt *DateTime) parse(value string) (int64, error) {
 		time.Time(tv).Year(),
 		time.Time(tv).Month(),
 		time.Time(tv).Day(),
-		time.Time(tv).Hour(),
-		time.Time(tv).Minute(),
-		time.Time(tv).Second(),
-		0, time.UTC,
+		0, 0, 0, 0, time.UTC,
 	).Unix(), nil
 }

--- a/lib/types/array.go
+++ b/lib/types/array.go
@@ -95,7 +95,6 @@ var columnsMap = map[reflect.Type]column.Column{
 	reflect.TypeOf([]float64{}): &column.Float64{},
 	reflect.TypeOf([]string{}):  &column.String{},
 	reflect.TypeOf([]time.Time{}): &column.DateTime{
-		IsFull:   true,
 		Timezone: time.Local,
 	},
 }


### PR DESCRIPTION
Sorry, I opened the older pr without a complete testing. It did not solve this problem [issue140](https://github.com/kshvakov/clickhouse/issues/140)

Now, I open this pr for this problem.

Insert by golang:
![image](https://user-images.githubusercontent.com/12894873/49239703-5d951080-f43e-11e8-96c7-cbd1223b387b.png)

Query by clickhouse-client:
![image](https://user-images.githubusercontent.com/12894873/49239784-93d29000-f43e-11e8-8e80-201614ec83f9.png)

Query by golang:
![image](https://user-images.githubusercontent.com/12894873/49240037-368b0e80-f43f-11e8-99ad-6f4494f0a10f.png)
