### PR TITLE
fix: date type out of range

### DIFF
--- a/lib/column/date.go
+++ b/lib/column/date.go
@@ -27,7 +27,7 @@ func (dt *Date) Write(encoder *binary.Encoder, v interface{}) error {
 		_, offset := value.Zone()
 		timestamp = value.Unix() + int64(offset)
 	case int16:
-		timestamp = int64(value) + dt.offset
+		return encoder.Int16(value)
 	case int32:
 		timestamp = int64(value) + dt.offset
 	case int64:
@@ -44,7 +44,7 @@ func (dt *Date) Write(encoder *binary.Encoder, v interface{}) error {
 		_, offset := value.Zone()
 		timestamp = (*value).Unix() + int64(offset)
 	case *int16:
-		timestamp = int64(*value) + dt.offset
+		return encoder.Int16(*value)
 	case *int32:
 		timestamp = int64(*value) + dt.offset
 	case *int64:


### PR DESCRIPTION
Clickhouse save date with Int16, if date add offset, it will be out of range.

```
CREATE TABLE default.test_date
(
    thedate Date,
    time DateTime
)
ENGINE = MergeTree
PARTITION BY thedate
ORDER BY thedate
SETTINGS index_granularity = 8192
```

```
    stmt, err := tx.Prepare("INSERT INTO test_date (thedate, time) VALUES (?, ?)")
    checkErr(err)

    date := int16(17868)
    if _, err := stmt.Exec(
        &date,
        time.Now(),
    ); err != nil {
        log.Fatal(err)
    }
    checkErr(tx.Commit())
    rows, err := connect.Query("SELECT time, thedate, toInt16(thedate) as t FROM test_date Order by time")

```
After 19:44:53, I try to return date direct in lib/column/date.go is right.

![image](https://user-images.githubusercontent.com/2883637/49373189-0e99f480-f738-11e8-9b6d-69bcbcf29438.png)

