### PR TITLE
add leaky byte pool for memory management, remove prealloc on dial

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Golang SQL database driver for [Yandex ClickHouse](https://clickhouse.yandex/)
     * random   - choose random server from set 
     * in_order - first live server is choosen in specified order
 * block_size - maximum rows in block (default is 1000000). If the rows are larger then the data will be split into several blocks to send them to the server
+* pool size - maximum amount of preallocated byte chunks used in queries (default is 100). Decrease this if you experience memory problems at the expense of more GC pressure and vice versa.
 * debug - enable debug output (boolean value)
 
 SSL/TLS parameters:

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -85,7 +85,7 @@ func open(dsn string) (*clickhouse, error) {
 		readTimeout      = DefaultReadTimeout
 		writeTimeout     = DefaultWriteTimeout
 		connOpenStrategy = connOpenRandom
-		poolSize         = 1000
+		poolSize         = 100
 	)
 	if len(database) == 0 {
 		database = DefaultDatabase

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -11,8 +11,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/kshvakov/clickhouse/lib/leakypool"
 
 	"github.com/kshvakov/clickhouse/lib/binary"
 	"github.com/kshvakov/clickhouse/lib/data"
@@ -30,6 +33,7 @@ var (
 	unixtime    int64
 	logOutput   io.Writer = os.Stdout
 	hostname, _           = os.Hostname()
+	poolInit    sync.Once
 )
 
 func init() {
@@ -81,6 +85,7 @@ func open(dsn string) (*clickhouse, error) {
 		readTimeout      = DefaultReadTimeout
 		writeTimeout     = DefaultWriteTimeout
 		connOpenStrategy = connOpenRandom
+		poolSize         = 1000
 	)
 	if len(database) == 0 {
 		database = DefaultDatabase
@@ -106,6 +111,12 @@ func open(dsn string) (*clickhouse, error) {
 	if size, err := strconv.ParseInt(query.Get("block_size"), 10, 64); err == nil {
 		blockSize = int(size)
 	}
+	if size, err := strconv.ParseInt(query.Get("pool_size"), 10, 64); err == nil {
+		poolSize = int(size)
+	}
+	poolInit.Do(func() {
+		leakypool.InitBytePool(poolSize)
+	})
 	if altHosts := strings.Split(query.Get("alt_hosts"), ","); len(altHosts) != 0 {
 		for _, host := range altHosts {
 			if len(host) != 0 {

--- a/connect.go
+++ b/connect.go
@@ -69,7 +69,7 @@ func dial(secure, skipVerify bool, hosts []string, readTimeout, writeTimeout tim
 				Conn:         conn,
 				logf:         logf,
 				ident:        ident,
-				buffer:       bufio.NewReaderSize(conn, 4*1024*1024),
+				buffer:       bufio.NewReader(conn),
 				readTimeout:  readTimeout,
 				writeTimeout: writeTimeout,
 			}, nil

--- a/lib/leakypool/leaky_pool.go
+++ b/lib/leakypool/leaky_pool.go
@@ -1,0 +1,23 @@
+package leakypool
+
+var pool chan []byte
+
+func InitBytePool(size int) {
+	pool = make(chan []byte, size)
+}
+
+func GetBytes(size, capacity int) (b []byte) {
+	select {
+	case b = <-pool:
+	default:
+		b = make([]byte, size, capacity)
+	}
+	return
+}
+
+func PutBytes(b []byte) {
+	select {
+	case pool <- b:
+	default:
+	}
+}


### PR DESCRIPTION
Our production load uses multiple transactions since the nature of the data varies a lot, along with the number of prepared statements. After many OoM machines, I profiled my application and here's the relevant part from a heap dump:

![pprof](http://i64.tinypic.com/21nqufd.jpg)

The `sync.Pool` used for `WriteBuffer` gets out of hand quite fast. I've replaced it with a leaky pool implementation that is much more easy on the memory. This does create more GC pressure, however it's barely noticeable and I can at least use the driver now. The size of this pool can be adjusted via driver string parameters, having a sensible 1000 as default.

The heap generated by `dial` happens when the driver experiences multiple consecutive errors. This is because the connection is closed and redialed in the case of an error. A large volume of errors that happen in a short time uses a lot of memory because of the preallocation made during dial. A misformed (whether it is user or library related) query can quickly fill the memory unnecessarily. This is why I've switched it to a simple `bufio.NewReader`. I think it's preferable to use more CPU (not that I've noticed) instead of jeopardizing the app/machine as a whole.

This code's been in production for 2 days and no problems so far. No more OoM machines, RAM usage dropped to 1/5.

Solves [#112](https://github.com/kshvakov/clickhouse/issues/112).