### PR TITLE
Fix a panic in write buffer with leaky pool

### DIFF
--- a/lib/writebuffer/buffer.go
+++ b/lib/writebuffer/buffer.go
@@ -25,13 +25,13 @@ func (wb *WriteBuffer) Write(data []byte) (int, error) {
 	)
 	for {
 		freeSize := cap(wb.chunks[chunkIdx]) - len(wb.chunks[chunkIdx])
-		if freeSize >= dataSize {
+		if freeSize >= len(data) {
 			wb.chunks[chunkIdx] = append(wb.chunks[chunkIdx], data...)
 			return dataSize, nil
 		}
 		wb.chunks[chunkIdx] = append(wb.chunks[chunkIdx], data[:freeSize]...)
 		data = data[freeSize:]
-		wb.addChunk(0, wb.calcCap(dataSize))
+		wb.addChunk(0, wb.calcCap(len(data)))
 		chunkIdx++
 	}
 }

--- a/lib/writebuffer/buffer_test.go
+++ b/lib/writebuffer/buffer_test.go
@@ -1,0 +1,16 @@
+package writebuffer
+
+import (
+	"testing"
+
+	"github.com/kshvakov/clickhouse/lib/leakypool"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WriteBuffer_SafeWithLeakyPool(t *testing.T) {
+	leakypool.InitBytePool(1)
+	wb := New(InitialSize)
+	wb.Write(make([]byte, 1))
+	leakypool.PutBytes(make([]byte, InitialSize))
+	assert.NotPanics(t, func() { wb.Write(make([]byte, InitialSize+1)) })
+}

--- a/lib/writebuffer/buffer_test.go
+++ b/lib/writebuffer/buffer_test.go
@@ -10,7 +10,13 @@ import (
 func Test_WriteBuffer_SafeWithLeakyPool(t *testing.T) {
 	leakypool.InitBytePool(1)
 	wb := New(InitialSize)
-	wb.Write(make([]byte, 1))
+	n, err := wb.Write(make([]byte, 1))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
 	leakypool.PutBytes(make([]byte, InitialSize))
-	assert.NotPanics(t, func() { wb.Write(make([]byte, InitialSize+1)) })
+	assert.NotPanics(t, func() {
+		n, err = wb.Write(make([]byte, InitialSize+1))
+		assert.Equal(t, InitialSize+1, n)
+		assert.NoError(t, err)
+	})
 }

--- a/lib/writebuffer/buffer_test.go
+++ b/lib/writebuffer/buffer_test.go
@@ -10,10 +10,13 @@ import (
 func Test_WriteBuffer_SafeWithLeakyPool(t *testing.T) {
 	leakypool.InitBytePool(1)
 	wb := New(InitialSize)
+
 	n, err := wb.Write(make([]byte, 1))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n)
+
 	leakypool.PutBytes(make([]byte, InitialSize))
+
 	assert.NotPanics(t, func() {
 		n, err = wb.Write(make([]byte, InitialSize+1))
 		assert.Equal(t, InitialSize+1, n)


### PR DESCRIPTION
There is a chance for write buffer to panic in the write loop when the newly allocated chunk is not larger than the size of the byte slice it is writing, the case is possible when there is a leaky pool in place.

Panic stack without the fix:
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 20 [running]:
testing.tRunner.func1(0xc000126100)
	/usr/local/Cellar/go/1.11.5/libexec/src/testing/testing.go:792 +0x6a7
panic(0x13e4580, 0x16b1a90)
	/usr/local/Cellar/go/1.11.5/libexec/src/runtime/panic.go:513 +0x1b9
github.com/cw9/clickhouse/lib/writebuffer.(*WriteBuffer).Write(0xc0000a64c0, 0xc0001effff, 0x40001, 0x2, 0x40001, 0x40001, 0x0)
	.../src/github.com/cw9/clickhouse/lib/writebuffer/buffer.go:32 +0x6d8
github.com/cw9/clickhouse/lib/writebuffer.Test_WriteBuffer_SafeWithLeakyPool(0xc000126100)
	.../src/github.com/cw9/clickhouse/lib/writebuffer/buffer_test.go:15 +0x14e
testing.tRunner(0xc000126100, 0x1447470)
	/usr/local/Cellar/go/1.11.5/libexec/src/testing/testing.go:827 +0x163
created by testing.(*T).Run
	/usr/local/Cellar/go/1.11.5/libexec/src/testing/testing.go:878 +0x65a