### PR TITLE
Fix dataSize not being updated while data size larger than chunk freeSize

### DIFF
--- a/lib/writebuffer/buffer.go
+++ b/lib/writebuffer/buffer.go
@@ -22,14 +22,17 @@ func (wb *WriteBuffer) Write(data []byte) (int, error) {
 	var (
 		chunkIdx = len(wb.chunks) - 1
 		dataSize = len(data)
+		writtenSize = 0
 	)
 	for {
 		freeSize := cap(wb.chunks[chunkIdx]) - len(wb.chunks[chunkIdx])
 		if freeSize >= len(data) {
 			wb.chunks[chunkIdx] = append(wb.chunks[chunkIdx], data...)
-			return dataSize, nil
+			writtenSize += len(data)
+			return writtenSize, nil
 		}
 		wb.chunks[chunkIdx] = append(wb.chunks[chunkIdx], data[:freeSize]...)
+		writtenSize += freeSize
 		data = data[freeSize:]
 		dataSize = dataSize - freeSize
 		wb.addChunk(0, wb.calcCap(len(data)))

--- a/lib/writebuffer/buffer.go
+++ b/lib/writebuffer/buffer.go
@@ -31,6 +31,7 @@ func (wb *WriteBuffer) Write(data []byte) (int, error) {
 		}
 		wb.chunks[chunkIdx] = append(wb.chunks[chunkIdx], data[:freeSize]...)
 		data = data[freeSize:]
+		dataSize = dataSize - freeSize
 		wb.addChunk(0, wb.calcCap(len(data)))
 		chunkIdx++
 	}


### PR DESCRIPTION
While writing data to chunks, if the `dataSize` is larger than the `freeSize` of the current size, the data will be cut, but the `dataSize` won't be updated accordingly. This would cause slices bound out of range in the case when single record is large enough. 