### PR TITLE
Add TLS config for client certs and allow setting connection timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	go install -race -v
 	go test -i -v
-	go test -race -v .
+	go test -race -timeout 30s -v .
 
 coverage:
 	go test -coverprofile=coverage.out -v .

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Golang SQL database driver for [Yandex ClickHouse](https://clickhouse.yandex/)
 SSL/TLS parameters:
 
 * secure - establish secure connection (default is false)
-* skip_verify - skip certificate verification (default is true)
+* skip_verify - skip certificate verification (default is false)
+* tls_config - name of a TLS config with client certificates, registered using `clickhouse.RegisterTLSConfig()`; implies secure to be true, unless explicitly specified
 
 example:
 ```

--- a/connect.go
+++ b/connect.go
@@ -26,7 +26,17 @@ const (
 	connOpenInOrder
 )
 
-func dial(secure, skipVerify bool, hosts []string, readTimeout, writeTimeout time.Duration, noDelay bool, openStrategy openStrategy, logf func(string, ...interface{})) (*connect, error) {
+type connOptions struct {
+	secure, skipVerify                     bool
+	tlsConfig                              *tls.Config
+	hosts                                  []string
+	connTimeout, readTimeout, writeTimeout time.Duration
+	noDelay                                bool
+	openStrategy                           openStrategy
+	logf                                   func(string, ...interface{})
+}
+
+func dial(options connOptions) (*connect, error) {
 	var (
 		err error
 		abs = func(v int) int {
@@ -38,40 +48,54 @@ func dial(secure, skipVerify bool, hosts []string, readTimeout, writeTimeout tim
 		conn  net.Conn
 		ident = abs(int(atomic.AddInt32(&tick, 1)))
 	)
-	for i := range hosts {
+	tlsConfig := options.tlsConfig
+	if options.secure {
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{}
+		}
+		tlsConfig.InsecureSkipVerify = options.skipVerify
+	}
+	for i := range options.hosts {
 		var num int
-		switch openStrategy {
+		switch options.openStrategy {
 		case connOpenInOrder:
 			num = i
 		case connOpenRandom:
-			num = (ident + i) % len(hosts)
+			num = (ident + i) % len(options.hosts)
 		}
 		switch {
-		case secure:
+		case options.secure:
 			conn, err = tls.DialWithDialer(
 				&net.Dialer{
 					Timeout: 5 * time.Second,
 				},
 				"tcp",
-				hosts[num],
-				&tls.Config{
-					InsecureSkipVerify: skipVerify,
-				})
+				options.hosts[num],
+				tlsConfig,
+			)
 		default:
-			conn, err = net.DialTimeout("tcp", hosts[num], 5*time.Second)
+			conn, err = net.DialTimeout("tcp", options.hosts[num], options.connTimeout)
 		}
 		if err == nil {
-			logf("[dial] secure=%t, skip_verify=%t, strategy=%s, ident=%d, server=%d -> %s", secure, skipVerify, openStrategy, ident, num, conn.RemoteAddr())
+			options.logf(
+				"[dial] secure=%t, skip_verify=%t, strategy=%s, ident=%d, server=%d -> %s",
+				options.secure,
+				options.skipVerify,
+				options.openStrategy,
+				ident,
+				num,
+				conn.RemoteAddr(),
+			)
 			if tcp, ok := conn.(*net.TCPConn); ok {
-				tcp.SetNoDelay(noDelay) // Disable or enable the Nagle Algorithm for this tcp socket
+				tcp.SetNoDelay(options.noDelay) // Disable or enable the Nagle Algorithm for this tcp socket
 			}
 			return &connect{
 				Conn:         conn,
-				logf:         logf,
+				logf:         options.logf,
 				ident:        ident,
 				buffer:       bufio.NewReader(conn),
-				readTimeout:  readTimeout,
-				writeTimeout: writeTimeout,
+				readTimeout:  options.readTimeout,
+				writeTimeout: options.writeTimeout,
 			}, nil
 		}
 	}

--- a/connect.go
+++ b/connect.go
@@ -87,7 +87,10 @@ func dial(options connOptions) (*connect, error) {
 				conn.RemoteAddr(),
 			)
 			if tcp, ok := conn.(*net.TCPConn); ok {
-				tcp.SetNoDelay(options.noDelay) // Disable or enable the Nagle Algorithm for this tcp socket
+				err = tcp.SetNoDelay(options.noDelay) // Disable or enable the Nagle Algorithm for this tcp socket
+				if err != nil {
+					return nil, err
+				}
 			}
 			return &connect{
 				Conn:         conn,

--- a/lib/writebuffer/buffer.go
+++ b/lib/writebuffer/buffer.go
@@ -20,8 +20,8 @@ type WriteBuffer struct {
 
 func (wb *WriteBuffer) Write(data []byte) (int, error) {
 	var (
-		chunkIdx = len(wb.chunks) - 1
-		dataSize = len(data)
+		chunkIdx    = len(wb.chunks) - 1
+		dataSize    = len(data)
 		writtenSize = 0
 	)
 	for {

--- a/tls_config.go
+++ b/tls_config.go
@@ -1,0 +1,45 @@
+package clickhouse
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+// Based on the original implementation in the project go-sql-driver/mysql:
+// https://github.com/go-sql-driver/mysql/blob/master/utils.go
+
+var (
+	tlsConfigLock     sync.RWMutex
+	tlsConfigRegistry map[string]*tls.Config
+)
+
+// RegisterTLSConfig registers a custom tls.Config to be used with sql.Open.
+func RegisterTLSConfig(key string, config *tls.Config) error {
+	tlsConfigLock.Lock()
+	if tlsConfigRegistry == nil {
+		tlsConfigRegistry = make(map[string]*tls.Config)
+	}
+
+	tlsConfigRegistry[key] = config
+	tlsConfigLock.Unlock()
+	return nil
+}
+
+// DeregisterTLSConfig removes the tls.Config associated with key.
+func DeregisterTLSConfig(key string) {
+	tlsConfigLock.Lock()
+	if tlsConfigRegistry != nil {
+		delete(tlsConfigRegistry, key)
+	}
+	tlsConfigLock.Unlock()
+}
+
+func getTLSConfigClone(key string) (config *tls.Config) {
+	tlsConfigLock.RLock()
+	if v, ok := tlsConfigRegistry[key]; ok {
+		config = v.Clone()
+	}
+	tlsConfigLock.RUnlock()
+	return
+}
+


### PR DESCRIPTION
* Add TLS config for client certs
* Allow setting connection timeout

Implementation is based on https://github.com/go-sql-driver/mysql/blob/master/utils.go and matches what was recently added to mailru/go-clickhouse in https://github.com/mailru/go-clickhouse/pull/70/files