### PR TITLE
two reading mode for decimal type

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -50,6 +50,7 @@ type clickhouse struct {
 	compress      bool
 	blockSize     int
 	inTransaction bool
+	decimalMode   int
 }
 
 func (ch *clickhouse) Prepare(query string) (driver.Stmt, error) {

--- a/clickhouse_read_block.go
+++ b/clickhouse_read_block.go
@@ -11,7 +11,11 @@ func (ch *clickhouse) readBlock() (*data.Block, error) {
 
 	ch.decoder.SelectCompress(ch.compress)
 	var block data.Block
-	if err := block.Read(&ch.ServerInfo, ch.decoder); err != nil {
+	option := data.BlockRWOption{
+		Timezone:    ch.ServerInfo.Timezone,
+		DecimalMode: ch.decimalMode,
+	}
+	if err := block.Read(&option, ch.decoder); err != nil {
 		return nil, err
 	}
 	ch.decoder.SelectCompress(false)

--- a/clickhouse_write_block.go
+++ b/clickhouse_write_block.go
@@ -34,7 +34,11 @@ func (ch *clickhouse) writeBlock(block *data.Block) error {
 		utils/compressor, TCPHandler.
 	*/
 	ch.encoder.SelectCompress(ch.compress)
-	err := block.Write(&ch.ServerInfo, ch.encoder)
+	option := data.BlockRWOption{
+		Timezone:    ch.ServerInfo.Timezone,
+		DecimalMode: ch.decimalMode,
+	}
+	err := block.Write(&option, ch.encoder)
 	ch.encoder.SelectCompress(false)
 	return err
 }

--- a/lib/column/array.go
+++ b/lib/column/array.go
@@ -59,7 +59,7 @@ func (array *Array) read(decoder *binary.Decoder, ln int) (interface{}, error) {
 	return slice.Interface(), nil
 }
 
-func parseArray(name, chType string, timezone *time.Location) (*Array, error) {
+func parseArray(name, chType string, timezone *time.Location, decimalMode int) (*Array, error) {
 	if len(chType) < 11 {
 		return nil, fmt.Errorf("invalid Array column type: %s", chType)
 	}
@@ -78,7 +78,7 @@ loop:
 			break loop
 		}
 	}
-	column, err := Factory(name, chType, timezone)
+	column, err := Factory(name, chType, timezone, decimalMode)
 	if err != nil {
 		return nil, fmt.Errorf("Array(T): %v", err)
 	}

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -18,7 +18,7 @@ type Column interface {
 	defaultValue() interface{}
 }
 
-func Factory(name, chType string, timezone *time.Location) (Column, error) {
+func Factory(name, chType string, timezone *time.Location, decimalMode int) (Column, error) {
 	switch chType {
 	case "Int8":
 		return &Int8{
@@ -140,15 +140,15 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 
 	switch {
 	case strings.HasPrefix(chType, "Array"):
-		return parseArray(name, chType, timezone)
+		return parseArray(name, chType, timezone, decimalMode)
 	case strings.HasPrefix(chType, "Nullable"):
-		return parseNullable(name, chType, timezone)
+		return parseNullable(name, chType, timezone, decimalMode)
 	case strings.HasPrefix(chType, "FixedString"):
 		return parseFixedString(name, chType)
 	case strings.HasPrefix(chType, "Enum8"), strings.HasPrefix(chType, "Enum16"):
 		return parseEnum(name, chType)
 	case strings.HasPrefix(chType, "Decimal"):
-		return parseDecimal(name, chType)
+		return parseDecimal(name, chType, decimalMode)
 	}
 	return nil, fmt.Errorf("column: unhandled type %v", chType)
 }

--- a/lib/column/column_benchmark_test.go
+++ b/lib/column/column_benchmark_test.go
@@ -168,7 +168,7 @@ func Benchmark_Column_String(b *testing.B) {
 func Benchmark_Column_FixedString(b *testing.B) {
 	var (
 		str       = []byte(fmt.Sprintf("str_%d", time.Now().Unix()))
-		column, _ = Factory("", "FixedString(14)", time.Local)
+		column, _ = Factory("", "FixedString(14)", time.Local, 0)
 		encoder   = binary.NewEncoder(ioutil.Discard)
 	)
 	b.ResetTimer()
@@ -182,7 +182,7 @@ func Benchmark_Column_FixedString(b *testing.B) {
 
 func Benchmark_Column_Enum8(b *testing.B) {
 	var (
-		column, _ = Factory("", "Enum8('A'=1, 'B'=2, 'C'=3)", time.Local)
+		column, _ = Factory("", "Enum8('A'=1, 'B'=2, 'C'=3)", time.Local, 0)
 		encoder   = binary.NewEncoder(ioutil.Discard)
 	)
 	b.ResetTimer()
@@ -196,7 +196,7 @@ func Benchmark_Column_Enum8(b *testing.B) {
 
 func Benchmark_Column_Enum16(b *testing.B) {
 	var (
-		column, _ = Factory("", "Enum16('A'=1,'B'=2,'C'=3)", time.Local)
+		column, _ = Factory("", "Enum16('A'=1,'B'=2,'C'=3)", time.Local, 0)
 		encoder   = binary.NewEncoder(ioutil.Discard)
 	)
 	b.ResetTimer()
@@ -210,7 +210,7 @@ func Benchmark_Column_Enum16(b *testing.B) {
 
 func Benchmark_Column_Date(b *testing.B) {
 	var (
-		column, _ = Factory("", "Date", time.Local)
+		column, _ = Factory("", "Date", time.Local, 0)
 		encoder   = binary.NewEncoder(ioutil.Discard)
 		timeNow   = time.Now()
 	)
@@ -225,7 +225,7 @@ func Benchmark_Column_Date(b *testing.B) {
 
 func Benchmark_Column_DateTime(b *testing.B) {
 	var (
-		column, _ = Factory("", "DateTime", time.Local)
+		column, _ = Factory("", "DateTime", time.Local, 0)
 		encoder   = binary.NewEncoder(ioutil.Discard)
 		timeNow   = time.Now()
 	)

--- a/lib/column/column_test.go
+++ b/lib/column/column_test.go
@@ -18,7 +18,7 @@ func Test_Column_Int8(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Int8", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Int8", time.Local, 0); assert.NoError(t, err) {
 		for i := -128; i <= 127; i++ {
 			if err := column.Write(encoder, int8(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -43,7 +43,7 @@ func Test_Column_Int16(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Int16", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Int16", time.Local, 0); assert.NoError(t, err) {
 		for i := -32768; i <= 32767; i++ {
 			if err := column.Write(encoder, int16(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -68,7 +68,7 @@ func Test_Column_Int32(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Int32", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Int32", time.Local, 0); assert.NoError(t, err) {
 		for i := -2147483648; i <= 2147483648; i += 100000 {
 			if err := column.Write(encoder, int32(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -93,7 +93,7 @@ func Test_Column_Int64(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Int64", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Int64", time.Local, 0); assert.NoError(t, err) {
 		for i := -2147483648; i <= 2147483648*2; i += 100000 {
 			if err := column.Write(encoder, int64(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -118,7 +118,7 @@ func Test_Column_UInt8(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "UInt8", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "UInt8", time.Local, 0); assert.NoError(t, err) {
 		for i := 0; i <= 255; i++ {
 			if err := column.Write(encoder, uint8(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -143,7 +143,7 @@ func Test_Column_UInt16(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "UInt16", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "UInt16", time.Local, 0); assert.NoError(t, err) {
 		for i := 0; i <= 65535; i++ {
 			if err := column.Write(encoder, uint16(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -168,7 +168,7 @@ func Test_Column_UInt32(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "UInt32", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "UInt32", time.Local, 0); assert.NoError(t, err) {
 		for i := 0; i <= 4294967295; i += 100000 {
 			if err := column.Write(encoder, uint32(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -193,7 +193,7 @@ func Test_Column_UInt64(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "UInt64", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "UInt64", time.Local, 0); assert.NoError(t, err) {
 		for i := 0; i <= 4294967295*2; i += 100000 {
 			if err := column.Write(encoder, uint64(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -218,7 +218,7 @@ func Test_Column_Float32(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Float32", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Float32", time.Local, 0); assert.NoError(t, err) {
 		for i := -2147483648; i <= 2147483648; i += 100000 {
 			if err := column.Write(encoder, float32(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -243,7 +243,7 @@ func Test_Column_Float64(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Float64", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Float64", time.Local, 0); assert.NoError(t, err) {
 		for i := -2147483648; i <= 2147483648*2; i += 100000 {
 			if err := column.Write(encoder, float64(i)); assert.NoError(t, err) {
 				if v, err := column.Read(decoder); assert.NoError(t, err) {
@@ -269,7 +269,7 @@ func Test_Column_String(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "String", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "String", time.Local, 0); assert.NoError(t, err) {
 		if err := column.Write(encoder, str); assert.NoError(t, err) {
 			if v, err := column.Read(decoder); assert.NoError(t, err) {
 				assert.Equal(t, str, v)
@@ -293,7 +293,7 @@ func Test_Column_FixedString(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "FixedString(14)", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "FixedString(14)", time.Local, 0); assert.NoError(t, err) {
 		if err := column.Write(encoder, str); assert.NoError(t, err) {
 			if v, err := column.Read(decoder); assert.NoError(t, err) {
 				assert.Equal(t, str, v)
@@ -316,7 +316,7 @@ func Test_Column_Enum8(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Enum8('A'=1,'B'=2,'C'=3)", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Enum8('A'=1,'B'=2,'C'=3)", time.Local, 0); assert.NoError(t, err) {
 		if err := column.Write(encoder, "B"); assert.NoError(t, err) {
 			if v, err := column.Read(decoder); assert.NoError(t, err) {
 				assert.Equal(t, "B", v)
@@ -346,7 +346,7 @@ func Test_Column_Enum16(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Enum16('A'=1,'B'=2,'C'=3)", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Enum16('A'=1,'B'=2,'C'=3)", time.Local, 0); assert.NoError(t, err) {
 		if err := column.Write(encoder, "B"); assert.NoError(t, err) {
 			if v, err := column.Read(decoder); assert.NoError(t, err) {
 				assert.Equal(t, "B", v)
@@ -376,7 +376,7 @@ func Test_Column_Date(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "Date", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "Date", time.Local, 0); assert.NoError(t, err) {
 		year, month, day := time.Now().Date()
 		today := time.Date(year, month, day, 0, 0, 0, 0, time.Local)
 
@@ -424,7 +424,7 @@ func Test_Column_DateTime(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "DateTime", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "DateTime", time.Local, 0); assert.NoError(t, err) {
 		if err := column.Write(encoder, timeNow); assert.NoError(t, err) {
 			if v, err := column.Read(decoder); assert.NoError(t, err) {
 				assert.Equal(t, timeNow, v)
@@ -452,7 +452,7 @@ func Test_Column_UUID(t *testing.T) {
 		encoder = binary.NewEncoder(&buf)
 		decoder = binary.NewDecoder(&buf)
 	)
-	if column, err := columns.Factory("column_name", "UUID", time.Local); assert.NoError(t, err) {
+	if column, err := columns.Factory("column_name", "UUID", time.Local, 0); assert.NoError(t, err) {
 		for _, uuid := range []string{
 			"00000000-0000-0000-0000-000000000000",
 			"6e6a7955-3237-3461-3036-663239386432",

--- a/lib/column/nullable.go
+++ b/lib/column/nullable.go
@@ -63,11 +63,11 @@ func (null *Nullable) WriteNull(nulls, encoder *binary.Encoder, v interface{}) e
 	return null.column.Write(encoder, v)
 }
 
-func parseNullable(name, chType string, timezone *time.Location) (*Nullable, error) {
+func parseNullable(name, chType string, timezone *time.Location, decimalMode int) (*Nullable, error) {
 	if len(chType) < 14 {
 		return nil, fmt.Errorf("invalid Nullable column type: %s", chType)
 	}
-	column, err := Factory(name, chType[9:][:len(chType)-10], timezone)
+	column, err := Factory(name, chType[9:][:len(chType)-10], timezone, decimalMode)
 	if err != nil {
 		return nil, fmt.Errorf("Nullable(T): %v", err)
 	}


### PR DESCRIPTION
#169 
For example:
We have a table test.
```
afd32d388a4d :) select * from test;

┌─────date─┬─user_id─┬─offers─┬─────cost─┐
│ 20180203 │       5 │      6 │ 789.5430 │
└──────────┴─────────┴────────┴──────────┘
```
Then, do some query.
```
$ go run test.go
do query: SELECT date, user_id, offers, cost FROM test                        
clickhouse sqlx: tcp://127.0.0.1:9000?decimal_mode=float                      
{Date:20180203 UserID:5 Offers:6 Cost:789.543}                                
clickhouse sqlx: tcp://127.0.0.1:9000
{Date:20180203 UserID:5 Offers:6 Cost:7.89543e+06}
```
