### PR TITLE
Fix compressed data read for Read()s that span multiple compressed payloads

### DIFF
--- a/lib/binary/compress_reader.go
+++ b/lib/binary/compress_reader.go
@@ -52,13 +52,10 @@ func (cr *compressReader) Read(buf []byte) (n int, err error) {
 		if err = cr.readCompressedData(); err != nil {
 			return bytesRead, err
 		}
-		if len(cr.data) < n-bytesRead {
-			bytesRead += len(cr.data)
-		} else {
-			bytesRead += n - bytesRead
-			cr.pos += n - bytesRead
-			break
-		}
+		copyedSize := copy(buf[bytesRead:], cr.data)
+
+		bytesRead += copyedSize
+		cr.pos = copyedSize
 	}
 	return n, nil
 }

--- a/lib/binary/compress_reader.go
+++ b/lib/binary/compress_reader.go
@@ -103,7 +103,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 			return
 		}
 	} else {
-		return fmt.Errorf("Unknown compression method: %d ", cr.header[0])
+		return fmt.Errorf("Unknown compression method: %d ", cr.header[16])
 	}
 
 	return nil

--- a/lib/binary/compress_reader.go
+++ b/lib/binary/compress_reader.go
@@ -103,7 +103,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 			return
 		}
 	} else {
-		return fmt.Errorf("Unknown compression method: %d ", cr.header[16])
+		return fmt.Errorf("Unknown compression method: 0x%02x ", cr.header[16])
 	}
 
 	return nil

--- a/lib/binary/compress_reader_clz4.go
+++ b/lib/binary/compress_reader_clz4.go
@@ -52,13 +52,10 @@ func (cr *compressReader) Read(buf []byte) (n int, err error) {
 		if err = cr.readCompressedData(); err != nil {
 			return bytesRead, err
 		}
-		if len(cr.data) < n-bytesRead {
-			bytesRead += len(cr.data)
-		} else {
-			bytesRead += n - bytesRead
-			cr.pos += n - bytesRead
-			break
-		}
+		copyedSize := copy(buf[bytesRead:], cr.data)
+
+		bytesRead += copyedSize
+		cr.pos = copyedSize
 	}
 	return n, nil
 }

--- a/lib/binary/compress_reader_clz4.go
+++ b/lib/binary/compress_reader_clz4.go
@@ -103,7 +103,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 			return
 		}
 	} else {
-		return fmt.Errorf("Unknown compression method: %d ", cr.header[0])
+		return fmt.Errorf("Unknown compression method: %d ", cr.header[16])
 	}
 
 	return nil

--- a/lib/binary/compress_reader_clz4.go
+++ b/lib/binary/compress_reader_clz4.go
@@ -103,7 +103,7 @@ func (cr *compressReader) readCompressedData() (err error) {
 			return
 		}
 	} else {
-		return fmt.Errorf("Unknown compression method: %d ", cr.header[16])
+		return fmt.Errorf("Unknown compression method: 0x%02x ", cr.header[16])
 	}
 
 	return nil


### PR DESCRIPTION
I ran into an issue when using compression which resulted in incorrect data being read when that data spanned two compressed payloads. The root cause of the issue is a missing copy() call in the code which is meant to combine decompressed data into a buffer. The behavior of the code should be:

```
copy data from the previously decompressed buffer
while the length of the read isn't satisfied {
    decompress the next payload into a buffer
    copy the decompressed data from the buffer
}
```

This PR adds the missing copy(), fixes an error message in the file, and formats that error message to be more easily read.