### PR TITLE
Set timeout properly for TLS connection 

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -67,7 +67,7 @@ func dial(options connOptions) (*connect, error) {
 		case options.secure:
 			conn, err = tls.DialWithDialer(
 				&net.Dialer{
-					Timeout: 5 * time.Second,
+					Timeout: options.connTimeout,
 				},
 				"tcp",
 				options.hosts[num],


### PR DESCRIPTION
The 'timeout' option isn't properly set for TLS connection, it's currently hard-coded to 5 seconds.
This PR set the timeout of the connection to the `timeout` option value like for insecure connections. 