### PR TITLE
Support IPv4 and IPv6 data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ tcp://host1:9000?username=user&password=qwerty&database=clicks&read_timeout=10&w
 * FixedString(N)
 * Date 
 * DateTime
+* IPv4
+* IPv6
 * Enum
 * UUID
 * Nullable(T)

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -185,7 +185,7 @@ func (ch *clickhouse) CheckNamedValue(nv *driver.NamedValue) error {
 		[]string:
 		return nil
 	case net.IP:
-		nv.Value = column.IP(v)
+		return nil
 	case driver.Valuer:
 		value, err := v.Value()
 		if err != nil {

--- a/lib/column/column.go
+++ b/lib/column/column.go
@@ -136,6 +136,20 @@ func Factory(name, chType string, timezone *time.Location) (Column, error) {
 			},
 			Timezone: timezone,
 		}, nil
+	case "IPv4":
+		return &IPv4{
+			base: base{
+				name:   name,
+				chType: chType,
+			},
+		}, nil
+	case "IPv6":
+		return &IPv6{
+			base: base{
+				name:   name,
+				chType: chType,
+			},
+		}, nil
 	}
 
 	switch {

--- a/lib/column/ipv4.go
+++ b/lib/column/ipv4.go
@@ -1,0 +1,33 @@
+package column
+
+import (
+	"net"
+
+	"github.com/kshvakov/clickhouse/lib/binary"
+)
+
+type IPv4 struct {
+	base
+}
+
+func (*IPv4) Read(decoder *binary.Decoder) (interface{}, error) {
+	v, err := decoder.Fixed(4)
+	if err != nil {
+		return nil, err
+	}
+	return net.IPv4(v[0], v[1], v[2], v[3]), nil
+}
+
+func (ip *IPv4) Write(encoder *binary.Encoder, v interface{}) error {
+	netIP, ok := v.(net.IP)
+	if !ok {
+		return &ErrUnexpectedType{
+			T:      v,
+			Column: ip,
+		}
+	}
+	if _, err := encoder.Write([]byte(netIP.To4())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/column/ipv6.go
+++ b/lib/column/ipv6.go
@@ -1,0 +1,33 @@
+package column
+
+import (
+	"net"
+
+	"github.com/kshvakov/clickhouse/lib/binary"
+)
+
+type IPv6 struct {
+	base
+}
+
+func (*IPv6) Read(decoder *binary.Decoder) (interface{}, error) {
+	v, err := decoder.Fixed(16)
+	if err != nil {
+		return nil, err
+	}
+	return net.IP(v), nil
+}
+
+func (ip *IPv6) Write(encoder *binary.Encoder, v interface{}) error {
+	netIP, ok := v.(net.IP)
+	if !ok {
+		return &ErrUnexpectedType{
+			T:      v,
+			Column: ip,
+		}
+	}
+	if _, err := encoder.Write([]byte(netIP.To16())); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
For insertion, handling of net.IP is taken over by new column types IPv4
and IPv6. Values of type net.IP can no longer be inserted into columns
of type FixedString(16).

For selection, columns of type IPv4 and IPv6 are returned as values with
type net.IP.

Addresses issue #188