### PR TITLE
Fix parsing number of argumnets for queries with BETWEEN (again)

### DIFF
--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -1262,8 +1262,8 @@ func Test_LikeQuery(t *testing.T) {
 			SELECT
 				firstName,
                 lastName
-			FROM clickhouse_test_like 
-			WHERE firstName LIKE ? and lastName LIKE ? 
+			FROM clickhouse_test_like
+			WHERE firstName LIKE ? and lastName LIKE ?
 		`
 	)
 	if connect, err := sql.Open("clickhouse", "tcp://127.0.0.1:9000?debug=true"); assert.NoError(t, err) && assert.NoError(t, connect.Ping()) {
@@ -1271,11 +1271,11 @@ func Test_LikeQuery(t *testing.T) {
 			if _, err := connect.Exec(ddl); assert.NoError(t, err) {
 				if tx, err := connect.Begin(); assert.NoError(t, err) {
 					if stmt, err := tx.Prepare(dml); assert.NoError(t, err) {
-						var names = []struct{
+						var names = []struct {
 							First string
-							Last string
+							Last  string
 						}{
-							{First: "JeanPierre", Last: "Baltasar"},{First: "DonPierre", Last: "Baltasar"},
+							{First: "JeanPierre", Last: "Baltasar"}, {First: "DonPierre", Last: "Baltasar"},
 						}
 						for i := range names {
 							_, err = stmt.Exec(
@@ -1289,40 +1289,40 @@ func Test_LikeQuery(t *testing.T) {
 					}
 					if assert.NoError(t, tx.Commit()) {
 						var tests = []struct {
-							Param1 string
-							Param2 string
+							Param1        string
+							Param2        string
 							ExpectedFirst string
-							ExpectedLast string
+							ExpectedLast  string
 						}{
 							{
-								Param1: "Don%",
-								Param2: "%lta%",
+								Param1:        "Don%",
+								Param2:        "%lta%",
 								ExpectedFirst: "DonPierre",
-								ExpectedLast: "Baltasar",
+								ExpectedLast:  "Baltasar",
 							},
 							{
-								Param1: "%eanP%",
-								Param2: "%asar",
+								Param1:        "%eanP%",
+								Param2:        "%asar",
 								ExpectedFirst: "JeanPierre",
-								ExpectedLast: "Baltasar",
+								ExpectedLast:  "Baltasar",
 							},
 							{
-								Param1: "Don",
-								Param2: "%asar",
+								Param1:        "Don",
+								Param2:        "%asar",
 								ExpectedFirst: "",
-								ExpectedLast: "",
+								ExpectedLast:  "",
 							},
 							{
-								Param1: "Jean%",
-								Param2: "%",
+								Param1:        "Jean%",
+								Param2:        "%",
 								ExpectedFirst: "JeanPierre",
-								ExpectedLast: "Baltasar",
+								ExpectedLast:  "Baltasar",
 							},
 							{
-								Param1: "%",
-								Param2: "Baptiste",
+								Param1:        "%",
+								Param2:        "Baptiste",
 								ExpectedFirst: "",
-								ExpectedLast: "",
+								ExpectedLast:  "",
 							},
 						}
 

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -376,6 +376,12 @@ func Test_Select(t *testing.T) {
 									assert.Equal(t, int(3), count)
 								}
 							}
+							if row := connect.QueryRow("SELECT COUNT(*) FROM clickhouse_test_select WHERE id BETWEEN ? AND ?", 0, 3); assert.NotNil(t, row) {
+								var count int
+								if err := row.Scan(&count); assert.NoError(t, err) {
+									assert.Equal(t, int(3), count)
+								}
+							}
 							if rows, err := connect.Query("SELECT id FROM clickhouse_test_select ORDER BY id LIMIT ?", 1); assert.NoError(t, err) {
 								i := 0
 								for rows.Next() {

--- a/stmt.go
+++ b/stmt.go
@@ -104,11 +104,14 @@ func (stmt *stmt) Close() error {
 
 func (stmt *stmt) bind(args []driver.NamedValue) string {
 	var (
-		buf     bytes.Buffer
-		index   int
-		keyword bool
-		like   = newMatcher("like")
-		limit   = newMatcher("limit")
+		buf       bytes.Buffer
+		index     int
+		keyword   bool
+		inBetween bool
+		like      = newMatcher("like")
+		limit     = newMatcher("limit")
+		between   = newMatcher("between")
+		and       = newMatcher("and")
 	)
 	switch {
 	case stmt.NumInput() != 0:
@@ -148,6 +151,12 @@ func (stmt *stmt) bind(args []driver.NamedValue) string {
 					default:
 						if limit.matchRune(char) || like.matchRune(char) {
 							keyword = true
+						} else if between.matchRune(char) {
+							keyword = true
+							inBetween = true
+						} else if inBetween && and.matchRune(char) {
+							keyword = true
+							inBetween = false
 						} else {
 							keyword = keyword && unicode.IsSpace(char)
 						}


### PR DESCRIPTION
Fix https://github.com/kshvakov/clickhouse/issues/83

Now it actually works :) Sorry, I just didn't run the code [last time](https://github.com/kshvakov/clickhouse/pull/186) - only tests.
I fixed parsing a number of arguments last time, and this pr fixes binding arguments.

There is also gofmt in `clickhouse_test.go`, so you can read only second commit.