### PR TITLE
Fix cancel not closing if write error

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -283,10 +283,16 @@ func (ch *clickhouse) process() error {
 
 func (ch *clickhouse) cancel() error {
 	ch.logf("[cancel request]")
-	if err := ch.encoder.Uvarint(protocol.ClientCancel); err != nil {
-		return err
+	// even if we fail to write the cancel, we still need to close
+	err := ch.encoder.Uvarint(protocol.ClientCancel)
+	if err == nil {
+		err = ch.encoder.Flush()
 	}
-	return ch.conn.Close()
+	// return the close error if there was one, otherwise return the write error
+	if cerr := ch.conn.Close(); cerr != nil {
+		return cerr
+	}
+	return err
 }
 
 func (ch *clickhouse) watchCancel(ctx context.Context) func() {


### PR DESCRIPTION
If there was an error writing the cancel message then `cancel` wouldn't close the connection. Additionally, if the write did succeed, it was never flushed, so in my debugging tcpdump's it was never actually sent to the server.

I made `cancel` return either the error from `Close` or the error from the write/flush. Though this ever is never actually used in `watchCancel`.