### PR TITLE
Add WriteArrayWithValue function to block

### DIFF
--- a/clickhouse_columnar_test.go
+++ b/clickhouse_columnar_test.go
@@ -28,7 +28,7 @@ func Test_ColumnarInsert(t *testing.T) {
 				enum8      Enum8 ('a' = 1, 'b' = 2),
 				enum16     Enum16('c' = 1, 'd' = 2),
 				array      Array(String),
-				array2     Array(String),
+				array2     Array(UInt64),
 				arrayArray Array(Array(String))
 			) Engine=Memory
 		`
@@ -108,7 +108,7 @@ func Test_ColumnarInsert(t *testing.T) {
 						block.WriteUInt8(10, 1)
 						block.WriteUInt16(11, 2)
 						block.WriteArray(12, []string{"A", "B", "C"})
-						block.WriteArrayWithValue(13, stringSliceValue{value: []string{"A", "B", "C"}})
+						block.WriteArrayWithValue(13, uint64SliceValue{value: []uint64{1, 2, 3}})
 						block.WriteArray(14, [][]string{[]string{"A", "B"}, []string{"CC", "DD", "EE"}})
 						if !assert.NoError(t, err) {
 							return
@@ -122,41 +122,42 @@ func Test_ColumnarInsert(t *testing.T) {
 	}
 }
 
-type stringValue struct {
-	value string
+type uint64Value struct {
+	value uint64
 }
 
-func (v stringValue) Kind() reflect.Kind {
+func (v uint64Value) Kind() reflect.Kind {
 	return reflect.String
 }
 
-func (v stringValue) Len() int {
-	panic("string has no length")
-}
-func (v stringValue) Index(i int) data.Value {
-	panic("string has no index")
+func (v uint64Value) Len() int {
+	panic("uint64 has no length")
 }
 
-func (v stringValue) Interface() interface{} {
+func (v uint64Value) Index(i int) data.Value {
+	panic("uint64 has no index")
+}
+
+func (v uint64Value) Interface() interface{} {
 	return v.value
 }
 
-type stringSliceValue struct {
-	value []string
+type uint64SliceValue struct {
+	value []uint64
 }
 
-func (v stringSliceValue) Kind() reflect.Kind {
+func (v uint64SliceValue) Kind() reflect.Kind {
 	return reflect.Slice
 }
 
-func (v stringSliceValue) Len() int {
+func (v uint64SliceValue) Len() int {
 	return len(v.value)
 }
 
-func (v stringSliceValue) Index(i int) data.Value {
-	return stringValue{value: v.value[i]}
+func (v uint64SliceValue) Index(i int) data.Value {
+	return uint64Value{value: v.value[i]}
 }
 
-func (v stringSliceValue) Interface() interface{} {
+func (v uint64SliceValue) Interface() interface{} {
 	return v.value
 }

--- a/lib/data/block.go
+++ b/lib/data/block.go
@@ -95,7 +95,7 @@ func (block *Block) Read(serverInfo *ServerInfo, decoder *binary.Decoder) (err e
 	return nil
 }
 
-func (block *Block) writeArray(column column.Column, value reflect.Value, num, level int) error {
+func (block *Block) writeArray(column column.Column, value Value, num, level int) error {
 	if level > column.Depth() {
 		return column.Write(block.buffers[num].Column, value.Interface())
 	}
@@ -137,7 +137,7 @@ func (block *Block) AppendRow(args []driver.Value) error {
 			if value.Kind() != reflect.Slice {
 				return fmt.Errorf("unsupported Array(T) type [%T]", value.Interface())
 			}
-			if err := block.writeArray(c, value, num, 1); err != nil {
+			if err := block.writeArray(c, newValue(value), num, 1); err != nil {
 				return err
 			}
 		case *column.Nullable:

--- a/lib/data/block_write_column.go
+++ b/lib/data/block_write_column.go
@@ -90,7 +90,10 @@ func (block *Block) WriteFixedString(c int, v []byte) error {
 }
 
 func (block *Block) WriteArray(c int, v interface{}) error {
-	value := reflect.ValueOf(v)
+	return block.WriteArrayWithValue(c, newValue(reflect.ValueOf(v)))
+}
+
+func (block *Block) WriteArrayWithValue(c int, value Value) error {
 	if value.Kind() != reflect.Slice {
 		return fmt.Errorf("unsupported Array(T) type [%T]", value.Interface())
 	}

--- a/lib/data/value.go
+++ b/lib/data/value.go
@@ -1,0 +1,33 @@
+package data
+
+import "reflect"
+
+// Value is a writable value.
+type Value interface {
+	// Kind returns value's Kind.
+	Kind() reflect.Kind
+
+	// Len returns value's length.
+	// It panics if value's Kind is not Array, Chan, Map, Slice, or String.
+	Len() int
+
+	// Index returns value's i'th element.
+	// It panics if value's Kind is not Array, Slice, or String or i is out of range.
+	Index(i int) Value
+
+	// Interface returns value's current value as an interface{}.
+	Interface() interface{}
+}
+
+// value is a wrapper that wraps reflect.Value to comply with Value interface.
+type value struct {
+	reflect.Value
+}
+
+func newValue(v reflect.Value) Value {
+	return value{Value: v}
+}
+
+func (v value) Index(i int) Value {
+	return newValue(v.Value.Index(i))
+}


### PR DESCRIPTION
This diff adds a `Value` interface and a `WriteArrayWithValue` function to block package. 

This allows user to provide custom implementation of `Value` and avoid unnecessary reflection cost.