### PR TITLE
add more uint64 case for uint column

### DIFF
--- a/lib/column/uint16.go
+++ b/lib/column/uint16.go
@@ -20,6 +20,8 @@ func (u *UInt16) Write(encoder *binary.Encoder, v interface{}) error {
 		return encoder.UInt16(v)
 	case int64:
 		return encoder.UInt16(uint16(v))
+	case uint64:
+		return encoder.UInt16(uint16(v))
 	case int:
 		return encoder.UInt16(uint16(v))
 
@@ -27,6 +29,8 @@ func (u *UInt16) Write(encoder *binary.Encoder, v interface{}) error {
 	case *uint16:
 		return encoder.UInt16(*v)
 	case *int64:
+		return encoder.UInt16(uint16(*v))
+	case *uint64:
 		return encoder.UInt16(uint16(*v))
 	case *int:
 		return encoder.UInt16(uint16(*v))

--- a/lib/column/uint32.go
+++ b/lib/column/uint32.go
@@ -18,12 +18,16 @@ func (u *UInt32) Write(encoder *binary.Encoder, v interface{}) error {
 	switch v := v.(type) {
 	case uint32:
 		return encoder.UInt32(v)
+	case uint64:
+		return encoder.UInt32(uint32(v))
 	case int64:
 		return encoder.UInt32(uint32(v))
 	case int:
 		return encoder.UInt32(uint32(v))
 
 	// this relies on Nullable never sending nil values through
+	case *uint64:
+		return encoder.UInt32(uint32(*v))
 	case *uint32:
 		return encoder.UInt32(*v)
 	case *int64:

--- a/lib/column/uint8.go
+++ b/lib/column/uint8.go
@@ -22,6 +22,8 @@ func (u *UInt8) Write(encoder *binary.Encoder, v interface{}) error {
 		return encoder.UInt8(v)
 	case int64:
 		return encoder.UInt8(uint8(v))
+	case uint64:
+		return encoder.UInt8(uint8(v))
 	case int:
 		return encoder.UInt8(uint8(v))
 
@@ -31,6 +33,8 @@ func (u *UInt8) Write(encoder *binary.Encoder, v interface{}) error {
 	case *uint8:
 		return encoder.UInt8(*v)
 	case *int64:
+		return encoder.UInt8(uint8(*v))
+	case *uint64:
 		return encoder.UInt8(uint8(*v))
 	case *int:
 		return encoder.UInt8(uint8(*v))


### PR DESCRIPTION
 we use code like this to parse the string to int:

```
	case "UInt8", "UInt16", "UInt32", "UInt64":
		ui, err := strconv.ParseUint(ifnull, 10, 64)
		if err != nil {
			return 0
		}
		return ui
```

it will panic when using UInt64 for UInt32 column, this's a simple fix for that case.

I'd like to switch all int case `int,int8,int16,int32,int64,  uint8,uint16,uint32,uint64`  in   `column/int*.go`  and `column/uint*.go`  . But got too much dirty paste,   golang really need template~~. Or we could do it by code gen.